### PR TITLE
feat(#6): add project scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# .NET build output
+bin/
+obj/
+*.user
+*.suo
+*.userprefs
+*.pidb
+
+# Rider / JetBrains
+.idea/
+*.sln.iml
+
+# Visual Studio
+.vs/
+*.vsidx
+
+# NuGet
+packages/
+*.nupkg
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build scripts artifacts
+dist/
+*.zip
+
+# Local environment
+global.json
+.env
+.env.local

--- a/QuackForge.sln
+++ b/QuackForge.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Loader", "src\QuackForge.Loader\QuackForge.Loader.csproj", "{A1B2C3D4-0001-0000-0000-000000000001}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# QuackForge
+
+> Level-based progression + endgame challenge content for **Escape from Duckov** (Team Soda, Unity 2022.3.5f1).
+
+QuackForge is a BepInEx 5 mod that adds:
+
+- **Leveling system** — XP from kills/quests, 5-stat point allocation (VIT / STR / AGI / PRE / SUR)
+- **Challenge Mode** — Boss Rush with time limits, limited lives, exclusive rewards
+- **New weapons & armors** — 10+ weapons / 5+ armors reusing existing assets, gated by blueprints
+
+See [`docs/QuackForge_Master_PRD_v2.0.md`](docs/QuackForge_Master_PRD_v2.0.md) for the full design.
+
+## Status
+
+**Phase 0 — Bootstrap** (in progress). Hello-world plugin that loads into BepInEx.
+
+## Requirements
+
+- Escape from Duckov (Steam)
+- [BepInEx 5.4.21](https://github.com/BepInEx/BepInEx/releases) (unix x64 on Mac, x64 on Windows)
+- .NET 8 SDK (for building from source)
+
+## Build
+
+```bash
+dotnet restore
+dotnet build -c Release
+```
+
+Output: `src/QuackForge.Loader/bin/Release/QuackForge.Loader.dll`
+
+## License
+
+MIT (see `LICENSE`).

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,38 @@
+# Development Setup
+
+See [`docs/QuackForge_Master_PRD_v2.0.md`](docs/QuackForge_Master_PRD_v2.0.md) **Part II** for the full environment spec. This file is a quick reference.
+
+## Prerequisites
+
+- **macOS (primary dev)**: Homebrew, .NET 8 SDK, JetBrains Rider, fswatch
+- **Windows 11 VM (QA)**: UTM + Windows 11 ARM evaluation
+- **Escape from Duckov** installed on both platforms
+- **BepInEx 5.4.21**
+  - Mac: `BepInEx_unix_x64_5.4.21.zip`
+  - Windows: `BepInEx_x64_5.4.21.zip`
+
+Detailed install steps live in PRD §2.2 (Mac), §2.3 (VM), §2.4 (Windows).
+
+## Build from source
+
+```bash
+dotnet restore
+dotnet build -c Release
+```
+
+## Deploy (Mac)
+
+```bash
+./scripts/deploy-mac.sh
+```
+
+Copies `QuackForge.Loader.dll` into `~/Library/Application Support/Steam/steamapps/common/Escape From Duckov/BepInEx/plugins/`.
+
+## Verify
+
+Launch Duckov and check `BepInEx/LogOutput.log`:
+
+```
+[Info   :   BepInEx] Loading [QuackForge 0.0.1]
+[Info   : QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.0.1)
+```

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -1,0 +1,48 @@
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using HarmonyLib;
+
+namespace QuackForge.Loader
+{
+    [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
+    public class Plugin : BaseUnityPlugin
+    {
+        public const string PluginGuid = "com.returntrue.quackforge";
+        public const string PluginName = "QuackForge";
+        public const string PluginVersion = "0.0.1";
+
+        public static ManualLogSource Log { get; private set; } = null!;
+
+        private Harmony _harmony = null!;
+        private ConfigEntry<bool> _enableMod = null!;
+
+        private void Awake()
+        {
+            Log = Logger;
+
+            _enableMod = Config.Bind(
+                section: "General",
+                key: "EnableMod",
+                defaultValue: true,
+                description: "Master switch for QuackForge. Disable to temporarily deactivate without uninstalling.");
+
+            if (!_enableMod.Value)
+            {
+                Log.LogWarning($"{PluginName} is disabled via config (General.EnableMod = false).");
+                return;
+            }
+
+            _harmony = new Harmony(PluginGuid);
+            _harmony.PatchAll();
+
+            Log.LogInfo($"\ud83e\udd86 {PluginName} is awake. Forging begins. (v{PluginVersion})");
+        }
+
+        private void OnDestroy()
+        {
+            _harmony?.UnpatchSelf();
+            Log?.LogInfo($"{PluginName} unloaded.");
+        }
+    }
+}

--- a/src/QuackForge.Loader/QuackForge.Loader.csproj
+++ b/src/QuackForge.Loader/QuackForge.Loader.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>QuackForge.Loader</AssemblyName>
+    <RootNamespace>QuackForge.Loader</RootNamespace>
+    <Version>0.0.1</Version>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <RestoreAdditionalProjectSources>https://nuget.bepinex.dev/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
+    <PackageReference Include="HarmonyX" Version="2.10.2" />
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Solution + `QuackForge.Loader` csproj targeting netstandard2.1
- BepInEx 5.4.21 plugin entrypoint (`Plugin.cs`) with master-switch config and empty `Harmony.PatchAll()`
- `.gitignore`, `README.md`, `SETUP.md` stubs

## Test plan
- [ ] `dotnet restore` succeeds (requires BepInEx NuGet feed)
- [ ] `dotnet build -c Release` produces `QuackForge.Loader.dll`
- [ ] Copy DLL to \`BepInEx/plugins/\`, launch Duckov, verify log line: \`🦆 QuackForge is awake. Forging begins. (v0.0.1)\`
- [ ] Toggle \`General.EnableMod = false\` in config → plugin short-circuits with warning

Closes #6