### PR TITLE
feat(#8): add Mac deploy script

### DIFF
--- a/scripts/deploy-mac.sh
+++ b/scripts/deploy-mac.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Build QuackForge.Loader in Release mode and deploy to local Duckov BepInEx plugins.
+# Usage: ./scripts/deploy-mac.sh [--skip-build] [--watch]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
+PLUGINS_DIR="$DUCKOV_DIR/BepInEx/plugins/QuackForge"
+BUILD_OUTPUT="$REPO_ROOT/src/QuackForge.Loader/bin/Release"
+
+SKIP_BUILD=0
+WATCH=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD=1 ;;
+    --watch)      WATCH=1 ;;
+    -h|--help)
+      sed -n '2,4p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+log() { printf '\033[0;36m[deploy-mac]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[deploy-mac]\033[0m %s\n' "$*" >&2; }
+
+check_duckov() {
+  if [[ ! -d "$DUCKOV_DIR" ]]; then
+    err "Duckov not found at: $DUCKOV_DIR"
+    err "Set DUCKOV_DIR env var to override."
+    exit 1
+  fi
+  if [[ ! -d "$DUCKOV_DIR/BepInEx" ]]; then
+    err "BepInEx not installed at: $DUCKOV_DIR/BepInEx"
+    err "Install BepInEx 5.4.21 first (see SETUP.md)."
+    exit 1
+  fi
+}
+
+build() {
+  log "dotnet build -c Release"
+  (cd "$REPO_ROOT" && dotnet build -c Release --nologo -v minimal)
+}
+
+deploy() {
+  local dll="$BUILD_OUTPUT/QuackForge.Loader.dll"
+  if [[ ! -f "$dll" ]]; then
+    err "Build output missing: $dll"
+    exit 1
+  fi
+  mkdir -p "$PLUGINS_DIR"
+  cp "$dll" "$PLUGINS_DIR/"
+  log "deployed → $PLUGINS_DIR/QuackForge.Loader.dll"
+}
+
+run_once() {
+  check_duckov
+  [[ "$SKIP_BUILD" -eq 0 ]] && build
+  deploy
+}
+
+if [[ "$WATCH" -eq 1 ]]; then
+  if ! command -v fswatch >/dev/null 2>&1; then
+    err "fswatch not installed. brew install fswatch"
+    exit 1
+  fi
+  run_once
+  log "watching src/ — Ctrl+C to stop"
+  fswatch -o "$REPO_ROOT/src" | while read -r _; do
+    run_once || err "build failed, continuing to watch"
+  done
+else
+  run_once
+fi


### PR DESCRIPTION
## Summary
- \`scripts/deploy-mac.sh\` — builds Release and copies \`QuackForge.Loader.dll\` into Duckov's \`BepInEx/plugins/QuackForge/\`
- \`--skip-build\` skips dotnet build (redeploy only)
- \`--watch\` rebuilds on change (requires \`fswatch\`)
- \`DUCKOV_DIR\` env var overrides default Steam library path
- Pre-flight checks: Duckov install + BepInEx presence

## Test plan
- [ ] \`./scripts/deploy-mac.sh\` builds and deploys successfully
- [ ] Duckov launches and logs \`🦆 QuackForge is awake.\`
- [ ] \`--skip-build\` redeploys existing DLL without rebuild
- [ ] \`--watch\` triggers on file change
- [ ] Missing Duckov path → script fails with clear error

Depends on #6 (scaffolding merged first or stacked). Closes #8.