### PR TITLE
fix(#2): Mac BepInEx 5.4.23.5 universal + Rosetta launcher

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -5,13 +5,14 @@ See [`docs/QuackForge_Master_PRD_v2.0.md`](docs/QuackForge_Master_PRD_v2.0.md) *
 ## Prerequisites
 
 - **macOS (primary dev)**: Homebrew, .NET 8 SDK, JetBrains Rider, fswatch
-- **Windows 11 VM (QA)**: UTM + Windows 11 ARM evaluation
+- **Windows 11 VM (QA)**: Parallels Desktop + Windows 11 ARM (x64 emulation)
 - **Escape from Duckov** installed on both platforms
-- **BepInEx 5.4.21**
-  - Mac: `BepInEx_unix_x64_5.4.21.zip`
-  - Windows: `BepInEx_x64_5.4.21.zip`
+- **BepInEx**
+  - Mac (arm64/x64): `BepInEx_macos_universal_5.4.23.5.zip` (native Apple Silicon)
+  - Windows (x64): `BepInEx_win_x64_5.4.21.0.zip` (or 5.4.23.5)
+- **Runtime note**: Duckov on Mac requires `steam_appid.txt` (AppID `3167020`) in the game directory to allow `run_bepinex.sh` standalone launch (bypasses Steam DRM `RestartAppIfNecessary` check).
 
-Detailed install steps live in PRD §2.2 (Mac), §2.3 (VM), §2.4 (Windows).
+Detailed install steps live in PRD §2.2 (Mac), §2.3 (VM), §2.4 (Windows). See also [`docs/vm-setup-guide.md`](docs/vm-setup-guide.md) for Parallels flow.
 
 ## Build from source
 
@@ -20,19 +21,37 @@ dotnet restore
 dotnet build -c Release
 ```
 
+## One-shot BepInEx install (Mac)
+
+```bash
+./scripts/install-bepinex-mac.sh
+```
+
+Downloads BepInEx 5.4.23.5 universal, extracts into Duckov dir, configures `run_bepinex.sh`, strips Gatekeeper xattrs, writes `steam_appid.txt` (AppID 3167020).
+
 ## Deploy (Mac)
 
 ```bash
 ./scripts/deploy-mac.sh
 ```
 
-Copies `QuackForge.Loader.dll` into `~/Library/Application Support/Steam/steamapps/common/Escape From Duckov/BepInEx/plugins/`.
+Copies `QuackForge.Loader.dll` into `~/Library/Application Support/Steam/steamapps/common/Escape From Duckov/BepInEx/plugins/QuackForge/`.
+
+## Launch Duckov with BepInEx loaded (Mac)
+
+```bash
+./scripts/run-duckov-mac.sh
+```
+
+Runs Duckov under Rosetta (x86_64) so `libdoorstop.dylib` can inject. On Apple Silicon this wrapper is required — BepInEx 5's MonoMod/HarmonyX native patching is not stable on arm64 Mono. The script handles the `arch -x86_64 → bash → exec` chain needed to survive macOS SIP stripping DYLD env vars.
 
 ## Verify
 
-Launch Duckov and check `BepInEx/LogOutput.log`:
+Check `BepInEx/LogOutput.log`:
 
 ```
-[Info   :   BepInEx] Loading [QuackForge 0.0.1]
+[Message: BepInEx] BepInEx 5.4.23.5 - Duckov
+[Info   : BepInEx] Detected Unity version: v2022.3.62f2
+[Message: BepInEx] Chainloader startup complete
 [Info   : QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.0.1)
 ```

--- a/docs/QuackForge_Master_PRD_v2.0.md
+++ b/docs/QuackForge_Master_PRD_v2.0.md
@@ -156,7 +156,7 @@
 | Git | 2.40+ | (이미 설치됨) | 버전 관리 |
 | fswatch | latest | `brew install fswatch` | watch 모드 자동 빌드 |
 | Steam + 덕코프 | — | (Steam에서 설치) | Mac 네이티브 실행 |
-| BepInEx 5 (unix x64) | 5.4.21 | GitHub Releases | 모드 로더 |
+| BepInEx 5 (macOS universal) | 5.4.23.5 | GitHub Releases | 모드 로더 (arm64 네이티브 지원) |
 
 ### Rider vs VS Code
 
@@ -177,24 +177,66 @@
 
 ### BepInEx 설치 절차 (Mac)
 
+> **변경 이력 (2026-04-17)**: PRD v2.0 초판의 `BepInEx_unix_x64_5.4.21` 은 Apple Silicon arm64 덕코프(Universal Binary) 에 로드 불가 (dyld 아키텍처 불일치, R0-2 실증). BepInEx 5.4.23.5 macos_universal 로 전환했으나, **Apple Silicon arm64 네이티브 실행에서 MonoMod/HarmonyX 의 런타임 패칭이 preloader 이후 진행되지 않는 현상 추가 발견** → 게임을 **Rosetta (x86_64 슬라이스)** 로 실행하는 런처 스크립트로 해결. macOS SIP가 `arch` 경계에서 `DYLD_INSERT_LIBRARIES` 를 제거하므로, 중간에 bash 래퍼를 두어 Rosetta 후 DYLD 재주입.
+
+자동 설치:
+
+```bash
+./scripts/install-bepinex-mac.sh
+```
+
+수동 동등:
+
 ```bash
 DUCKOV="$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov"
 cd "$DUCKOV"
 
-# 1. BepInEx_unix_x64_5.4.21.zip 다운로드 (GitHub Releases)
-unzip ~/Downloads/BepInEx_unix_x64_5.4.21.zip
+# 1. BepInEx 5.4.23.5 macos_universal 다운로드
+gh release download v5.4.23.5 --repo BepInEx/BepInEx -p "BepInEx_macos_universal_5.4.23.5.zip"
+unzip BepInEx_macos_universal_5.4.23.5.zip
 
-# 2. 실행 권한 부여
+# 2. run_bepinex.sh executable_name 설정 + 실행 권한
+sed -i '' 's|executable_name=""|executable_name="Duckov.app"|' run_bepinex.sh
 chmod +x run_bepinex.sh
 
-# 3. macOS 차단 플래그 제거
-xattr -cr "$DUCKOV"
+# 3. macOS Gatekeeper 플래그 제거
+xattr -cr BepInEx libdoorstop.dylib run_bepinex.sh
 
-# 4. 첫 실행 (BepInEx 폴더 자동 생성 트리거)
-./run_bepinex.sh
+# 4. Steam DRM 우회 (Steamworks.NET RestartAppIfNecessary)
+printf "3167020" > steam_appid.txt
 ```
 
-확인: `BepInEx/LogOutput.log` 에 BepInEx 로드 메시지가 보여야 함.
+실행:
+
+```bash
+./scripts/run-duckov-mac.sh   # arch -x86_64 + bash wrapper + DYLD 재주입
+```
+
+**확인**: `BepInEx/LogOutput.log` 에 다음 메시지가 보여야 함.
+
+```
+[Message:   BepInEx] BepInEx 5.4.23.5 - Duckov
+[Info   :   BepInEx] Running under Unity vUnknown (post-2017)
+[Message:   BepInEx] Preloader started
+[Info   :   BepInEx] Detected Unity version: v2022.3.62f2
+[Message:   BepInEx] Chainloader startup complete
+```
+
+### 런타임 주의
+
+| 항목 | 값 |
+|---|---|
+| Unity 버전 (게임 빌드) | 2022.3.62f2 (PRD 초판 2022.3.5f1 에서 게임 업데이트됨) |
+| Mac 덕코프 바이너리 | Universal Binary (x86_64 + arm64), ad-hoc 코드서명 |
+| 실행 아키텍처 | **x86_64 (Rosetta)** — arm64 는 BepInEx 5 미지원 |
+| Steam AppID | 3167020 (`steam_appid.txt` 필요) |
+
+### NuGet 컴파일 참조 vs 런타임
+
+| 구성요소 | 버전 | 이유 |
+|---|---|---|
+| `BepInEx.Core` (NuGet, csproj) | 5.4.21 | BepInEx NuGet 피드의 stable 최신. 5.4.x 내 API 호환 |
+| `BepInEx` (런타임 바이너리) | 5.4.23.5 macos_universal | 최신 doorstop, universal dylib |
 
 ## 2.3 Windows VM QA 환경
 

--- a/scripts/install-bepinex-mac.sh
+++ b/scripts/install-bepinex-mac.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# One-shot installer for BepInEx 5.4.23.5 macos_universal into Duckov.
+# Idempotent: safe to re-run.
+#
+# Background: see PRD §2.2. Apple Silicon arm64 Duckov + BepInEx 5.4.21 unix_x64
+# dies with dyld arch mismatch, and Rosetta via `arch` is defeated by SIP.
+# 5.4.23.5 ships a universal libdoorstop.dylib, and run-duckov-mac.sh handles
+# the Rosetta+env re-export dance.
+#
+# Usage: ./scripts/install-bepinex-mac.sh
+
+set -euo pipefail
+
+DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
+BEPINEX_TAG="v5.4.23.5"
+BEPINEX_ASSET="BepInEx_macos_universal_5.4.23.5.zip"
+APPID="3167020"
+
+log() { printf '\033[0;36m[install-bepinex]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[install-bepinex]\033[0m %s\n' "$*" >&2; }
+
+if [ ! -d "$DUCKOV_DIR" ]; then
+  err "Duckov not found at: $DUCKOV_DIR"
+  err "Install Escape from Duckov via Steam first."
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+log "downloading $BEPINEX_ASSET from BepInEx/$BEPINEX_TAG"
+if command -v gh >/dev/null 2>&1; then
+  gh release download "$BEPINEX_TAG" --repo BepInEx/BepInEx -p "$BEPINEX_ASSET" --dir "$TMP"
+else
+  curl -fsSL -o "$TMP/$BEPINEX_ASSET" \
+    "https://github.com/BepInEx/BepInEx/releases/download/$BEPINEX_TAG/$BEPINEX_ASSET"
+fi
+
+log "extracting into $DUCKOV_DIR"
+unzip -o -q "$TMP/$BEPINEX_ASSET" -d "$DUCKOV_DIR"
+
+log "configuring run_bepinex.sh executable_name=Duckov.app"
+sed -i '' 's|^executable_name=""$|executable_name="Duckov.app"|' "$DUCKOV_DIR/run_bepinex.sh"
+chmod +x "$DUCKOV_DIR/run_bepinex.sh"
+
+log "stripping macOS Gatekeeper quarantine flags"
+xattr -cr "$DUCKOV_DIR/BepInEx" "$DUCKOV_DIR/libdoorstop.dylib" "$DUCKOV_DIR/run_bepinex.sh"
+
+log "writing steam_appid.txt ($APPID) to bypass Steam DRM RestartAppIfNecessary"
+printf "%s" "$APPID" > "$DUCKOV_DIR/steam_appid.txt"
+
+log "done. Launch with: ./scripts/run-duckov-mac.sh"
+log "verify BepInEx log at: $DUCKOV_DIR/BepInEx/LogOutput.log"

--- a/scripts/run-duckov-mac.sh
+++ b/scripts/run-duckov-mac.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Launch Duckov on macOS Apple Silicon with BepInEx 5.4.23.5 loaded.
+#
+# Why this script exists instead of the stock run_bepinex.sh:
+#
+#   Duckov ships as a Universal Binary (x86_64 + arm64). On Apple Silicon the
+#   default exec selects arm64, which rules out BepInEx 5 because MonoMod /
+#   HarmonyX 2.10 native patching is not reliable on arm64 Mono yet — the
+#   preloader loads but hangs before the log system comes up.
+#
+#   The fix is to run the game under Rosetta (x86_64 slice) while still
+#   injecting libdoorstop. But macOS SIP strips DYLD_* across the `arch`
+#   boundary, even with `arch -e KEY=val`. So we do:
+#
+#     arch -x86_64  ->  bash wrapper (re-exports DYLD_*)  ->  exec Duckov
+#
+#   The bash -> exec step is not a SIP boundary, so DYLD_INSERT_LIBRARIES
+#   survives into the game process.
+#
+#   Duckov additionally requires steam_appid.txt (AppID 3167020) in the game
+#   directory so Steamworks.NET RestartAppIfNecessary does not kill us.
+#
+# Usage: ./scripts/run-duckov-mac.sh
+
+set -u
+
+DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
+EXE="$DUCKOV_DIR/Duckov.app/Contents/MacOS/Duckov"
+DYLIB="$DUCKOV_DIR/libdoorstop.dylib"
+PRELOADER="$DUCKOV_DIR/BepInEx/core/BepInEx.Preloader.dll"
+APPID_FILE="$DUCKOV_DIR/steam_appid.txt"
+
+err() { printf '\033[0;31m[run-duckov]\033[0m %s\n' "$*" >&2; }
+log() { printf '\033[0;36m[run-duckov]\033[0m %s\n' "$*"; }
+
+for f in "$EXE" "$DYLIB" "$PRELOADER"; do
+  if [ ! -f "$f" ]; then
+    err "missing: $f"
+    err "Run: ./scripts/install-bepinex-mac.sh (or see PRD §2.2)"
+    exit 1
+  fi
+done
+
+if [ ! -f "$APPID_FILE" ]; then
+  log "writing $APPID_FILE (Steam AppID 3167020 bypasses RestartAppIfNecessary)"
+  printf "3167020" > "$APPID_FILE"
+fi
+
+# Stage 1: re-export Rosetta-safe env, exec Duckov.
+# This runs only when we are already under arch -x86_64 (stage 2 below).
+if [ "${QUACKFORGE_ROSETTA_STAGE:-0}" = "1" ]; then
+  export DYLD_INSERT_LIBRARIES="$DYLIB"
+  export DYLD_LIBRARY_PATH="$DUCKOV_DIR"
+  export DOORSTOP_ENABLED=1
+  export DOORSTOP_TARGET_ASSEMBLY="$PRELOADER"
+  export DOORSTOP_IGNORE_DISABLED_ENV=0
+  export DOORSTOP_MONO_DEBUG_ENABLED=0
+  export DOORSTOP_MONO_DEBUG_ADDRESS="127.0.0.1:10000"
+  export DOORSTOP_MONO_DEBUG_SUSPEND=0
+  export DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE=""
+  export DOORSTOP_BOOT_CONFIG_OVERRIDE=""
+  export DOORSTOP_CLR_RUNTIME_CORECLR_PATH=".dylib"
+  export DOORSTOP_CLR_CORLIB_DIR=""
+  exec "$EXE"
+fi
+
+# Stage 2: re-invoke self under Rosetta.
+log "launching Duckov under Rosetta (x86_64) with BepInEx"
+export QUACKFORGE_ROSETTA_STAGE=1
+exec arch -x86_64 "$0" "$@"


### PR DESCRIPTION
## Summary
Apple Silicon arm64 덕코프에서 BepInEx 로드 실동작 확인.

**검증 로그** (`BepInEx/LogOutput.log`):
```
[Message: BepInEx] BepInEx 5.4.23.5 - Duckov (4/17/2026 4:07:09 PM)
[Info   : BepInEx] Detected Unity version: v2022.3.62f2
[Info   : BepInEx] 0 plugins to load
[Message: BepInEx] Chainloader startup complete
```

## 발견한 4가지 블로커

1. **dyld 아키텍처 불일치** — PRD 기준 `BepInEx_unix_x64_5.4.21` 은 arm64 Duckov 로드 실패. `BepInEx_macos_universal_5.4.23.5` 로 업그레이드.
2. **macOS SIP DYLD 스트립** — `arch -x86_64` 로 Rosetta 실행 시 `DYLD_INSERT_LIBRARIES` 가 삭제됨 (확인 완료). `arch -e` 플래그도 무효. 해결: `arch -x86_64 → bash 래퍼 → DYLD 재주입 → exec Duckov` 체인.
3. **arm64 MonoMod/HarmonyX 패칭 실패** — 네이티브 arm64 실행 시 BepInEx preloader 가 config 생성 후 Chainloader 전에 멈춤. Rosetta x86_64 슬라이스로 우회.
4. **Steam DRM RestartAppIfNecessary** — Steamworks.NET 가 standalone 실행 시 종료 유도. `steam_appid.txt` (AppID `3167020`) 로 우회.

## Changes
- `docs/QuackForge_Master_PRD_v2.0.md` §2.2 재작성 + Unity 버전 2022.3.5f1 → 2022.3.62f2 (게임 업데이트), BepInEx 버전 테이블, NuGet vs 런타임 분리
- `SETUP.md` — install-bepinex-mac.sh / run-duckov-mac.sh 사용 절차
- `scripts/install-bepinex-mac.sh` — BepInEx 다운로드/배치/xattr/steam_appid 자동화 (idempotent)
- `scripts/run-duckov-mac.sh` — `arch -x86_64 → bash → exec` 2단계 + DYLD 재주입 런처

## Test plan
- [x] `./scripts/install-bepinex-mac.sh` 로 재설치 가능
- [x] `./scripts/run-duckov-mac.sh` 실행 시 `BepInEx/LogOutput.log` 생성
- [x] LogOutput.log 에 "BepInEx 5.4.23.5 - Duckov" + Chainloader 메시지
- [ ] `dotnet build` → `deploy-mac.sh` → Plugin 로드 경로 end-to-end (#7 검증 후 별도)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)