### PR TITLE
feat(#12): QuackForge.Core module (Config/Logger/EventBus/SaveContext)

### DIFF
--- a/QuackForge.sln
+++ b/QuackForge.sln
@@ -1,21 +1,53 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.0.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Loader", "src\QuackForge.Loader\QuackForge.Loader.csproj", "{A1B2C3D4-0001-0000-0000-000000000001}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Core", "src\QuackForge.Core\QuackForge.Core.csproj", "{02EE985A-1D28-4574-AC4B-460CD9A92254}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-0001-0000-0000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-0001-0000-0000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0000-0000-000000000001}.Release|x86.Build.0 = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|x64.Build.0 = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Debug|x86.Build.0 = Debug|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x64.ActiveCfg = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x64.Build.0 = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x86.ActiveCfg = Release|Any CPU
+		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{02EE985A-1D28-4574-AC4B-460CD9A92254} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/scripts/deploy-mac.sh
+++ b/scripts/deploy-mac.sh
@@ -50,14 +50,20 @@ build() {
 }
 
 deploy() {
-  local dll="$BUILD_OUTPUT/QuackForge.Loader.dll"
-  if [[ ! -f "$dll" ]]; then
-    err "Build output missing: $dll"
+  local loader="$BUILD_OUTPUT/QuackForge.Loader.dll"
+  if [[ ! -f "$loader" ]]; then
+    err "Build output missing: $loader"
     exit 1
   fi
   mkdir -p "$PLUGINS_DIR"
-  cp "$dll" "$PLUGINS_DIR/"
-  log "deployed → $PLUGINS_DIR/QuackForge.Loader.dll"
+  local count=0
+  for dll in "$BUILD_OUTPUT"/QuackForge.*.dll; do
+    [[ -f "$dll" ]] || continue
+    cp "$dll" "$PLUGINS_DIR/"
+    log "deployed → $PLUGINS_DIR/$(basename "$dll")"
+    count=$((count + 1))
+  done
+  log "$count DLLs deployed"
 }
 
 run_once() {

--- a/src/QuackForge.Core/Config/QfConfig.cs
+++ b/src/QuackForge.Core/Config/QfConfig.cs
@@ -1,0 +1,18 @@
+using System;
+using BepInEx.Configuration;
+
+namespace QuackForge.Core.Config
+{
+    public sealed class QfConfig
+    {
+        private readonly ConfigFile _file;
+
+        public QfConfig(ConfigFile file)
+        {
+            _file = file ?? throw new ArgumentNullException(nameof(file));
+        }
+
+        public ConfigEntry<T> Bind<T>(string section, string key, T defaultValue, string description)
+            => _file.Bind(section, key, defaultValue, description);
+    }
+}

--- a/src/QuackForge.Core/Events/QfEventBus.cs
+++ b/src/QuackForge.Core/Events/QfEventBus.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuackForge.Core.Events
+{
+    public sealed class QfEventBus
+    {
+        private readonly object _lock = new object();
+        private readonly Dictionary<Type, Delegate> _handlers = new Dictionary<Type, Delegate>();
+
+        public void Subscribe<TEvent>(Action<TEvent> handler) where TEvent : notnull
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+            lock (_lock)
+            {
+                if (_handlers.TryGetValue(typeof(TEvent), out var existing))
+                    _handlers[typeof(TEvent)] = Delegate.Combine(existing, handler);
+                else
+                    _handlers[typeof(TEvent)] = handler;
+            }
+        }
+
+        public void Unsubscribe<TEvent>(Action<TEvent> handler) where TEvent : notnull
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+            lock (_lock)
+            {
+                if (!_handlers.TryGetValue(typeof(TEvent), out var existing)) return;
+                var remaining = Delegate.Remove(existing, handler);
+                if (remaining == null) _handlers.Remove(typeof(TEvent));
+                else _handlers[typeof(TEvent)] = remaining;
+            }
+        }
+
+        public void Publish<TEvent>(TEvent evt) where TEvent : notnull
+        {
+            Delegate? snapshot;
+            lock (_lock)
+            {
+                _handlers.TryGetValue(typeof(TEvent), out snapshot);
+            }
+            if (snapshot is Action<TEvent> typed) typed(evt);
+        }
+    }
+}

--- a/src/QuackForge.Core/Logging/QfLogger.cs
+++ b/src/QuackForge.Core/Logging/QfLogger.cs
@@ -1,0 +1,49 @@
+using System;
+using BepInEx.Logging;
+
+namespace QuackForge.Core.Logging
+{
+    public static class QfLogger
+    {
+        private static ManualLogSource? _root;
+
+        public static void Init(ManualLogSource rootLog)
+        {
+            _root = rootLog ?? throw new ArgumentNullException(nameof(rootLog));
+        }
+
+        public static IQfLog For(string tag)
+        {
+            if (string.IsNullOrWhiteSpace(tag)) throw new ArgumentException("tag required", nameof(tag));
+            if (_root == null) throw new InvalidOperationException("QfLogger.Init must be called from Plugin.Awake before any module logs.");
+            return new TaggedLog(_root, tag);
+        }
+
+        private sealed class TaggedLog : IQfLog
+        {
+            private readonly ManualLogSource _inner;
+            private readonly string _prefix;
+
+            internal TaggedLog(ManualLogSource inner, string tag)
+            {
+                _inner = inner;
+                _prefix = "[" + tag + "] ";
+            }
+
+            public void Debug(string message) => _inner.LogDebug(_prefix + message);
+            public void Info(string message)  => _inner.LogInfo(_prefix + message);
+            public void Warn(string message)  => _inner.LogWarning(_prefix + message);
+            public void Error(string message) => _inner.LogError(_prefix + message);
+            public void Error(string message, Exception ex) => _inner.LogError(_prefix + message + " :: " + ex);
+        }
+    }
+
+    public interface IQfLog
+    {
+        void Debug(string message);
+        void Info(string message);
+        void Warn(string message);
+        void Error(string message);
+        void Error(string message, Exception ex);
+    }
+}

--- a/src/QuackForge.Core/QfCore.cs
+++ b/src/QuackForge.Core/QfCore.cs
@@ -1,0 +1,38 @@
+using System;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using QuackForge.Core.Config;
+using QuackForge.Core.Events;
+using QuackForge.Core.Logging;
+using QuackForge.Core.Save;
+
+namespace QuackForge.Core
+{
+    public sealed class QfCore
+    {
+        public static QfCore? Instance { get; private set; }
+
+        public QfConfig Config { get; }
+        public QfEventBus Events { get; }
+        public QfSaveContext Save { get; }
+
+        private QfCore(QfConfig config, QfEventBus events, QfSaveContext save)
+        {
+            Config = config;
+            Events = events;
+            Save = save;
+        }
+
+        public static QfCore Initialize(ManualLogSource rootLog, ConfigFile configFile)
+        {
+            if (Instance != null) throw new InvalidOperationException("QfCore already initialized.");
+            if (rootLog == null) throw new ArgumentNullException(nameof(rootLog));
+            if (configFile == null) throw new ArgumentNullException(nameof(configFile));
+
+            QfLogger.Init(rootLog);
+            Instance = new QfCore(new QfConfig(configFile), new QfEventBus(), new QfSaveContext());
+            QfLogger.For("Core").Info("QfCore initialized.");
+            return Instance;
+        }
+    }
+}

--- a/src/QuackForge.Core/QuackForge.Core.csproj
+++ b/src/QuackForge.Core/QuackForge.Core.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyName>QuackForge.Loader</AssemblyName>
-    <RootNamespace>QuackForge.Loader</RootNamespace>
+    <AssemblyName>QuackForge.Core</AssemblyName>
+    <RootNamespace>QuackForge.Core</RootNamespace>
     <Version>0.0.1</Version>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -14,13 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
-    <PackageReference Include="HarmonyX" Version="2.10.2" />
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\QuackForge.Core\QuackForge.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Core/Save/QfSaveContext.cs
+++ b/src/QuackForge.Core/Save/QfSaveContext.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuackForge.Core.Save
+{
+    // Phase 1 stub: in-memory store. Phase 2 (T2.5) 에서 quackforge.json 사이드카로 확장.
+    // 게임의 SavesSystem 직접 사용이 아닌 사이드카 전략 (PRD 결정 2-1).
+    public sealed class QfSaveContext
+    {
+        private readonly Dictionary<string, object?> _store = new Dictionary<string, object?>(StringComparer.Ordinal);
+        private readonly object _lock = new object();
+
+        public void Set<T>(string key, T value)
+        {
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
+            lock (_lock) _store[key] = value;
+        }
+
+        public bool TryGet<T>(string key, out T value)
+        {
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
+            lock (_lock)
+            {
+                if (_store.TryGetValue(key, out var raw) && raw is T typed)
+                {
+                    value = typed;
+                    return true;
+                }
+            }
+            value = default!;
+            return false;
+        }
+
+        public bool Remove(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
+            lock (_lock) return _store.Remove(key);
+        }
+
+        public void Clear()
+        {
+            lock (_lock) _store.Clear();
+        }
+    }
+}

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -2,6 +2,7 @@ using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
+using QuackForge.Core;
 
 namespace QuackForge.Loader
 {
@@ -32,6 +33,8 @@ namespace QuackForge.Loader
                 Log.LogWarning($"{PluginName} is disabled via config (General.EnableMod = false).");
                 return;
             }
+
+            QfCore.Initialize(Log, Config);
 
             _harmony = new Harmony(PluginGuid);
             _harmony.PatchAll();


### PR DESCRIPTION
## Summary
PRD §5.5.1 Core 모듈 구현. Phase 2 이후 모든 모듈이 의존하는 공통 인프라.

## Components

| 컴포넌트 | 역할 | API 핵심 |
|---|---|---|
| \`QfLogger\` | 모듈 태그 로거 | \`QfLogger.For("ModuleName")\` → \`IQfLog\` |
| \`QfConfig\` | 설정 래퍼 | \`Bind<T>(section, key, default, desc)\` |
| \`QfEventBus\` | 타입 기반 pub/sub | \`Subscribe<T>\` / \`Publish<T>\` / \`Unsubscribe<T>\` (thread-safe) |
| \`QfSaveContext\` | 키-값 저장 (in-memory stub) | \`Set<T>\` / \`TryGet<T>\` / \`Remove\` |
| \`QfCore\` | 컴포지션 루트 (싱글턴) | \`Initialize(log, config)\` |

### 프로젝트 구조

- 신규 \`src/QuackForge.Core/QuackForge.Core.csproj\` (netstandard2.1, BepInEx.Core 5.4.21)
- \`QuackForge.Loader\` 가 ProjectReference 로 의존
- 솔루션에 추가

### Plugin.Awake 초기화

\`\`\`csharp
QfCore.Initialize(Log, Config);  // enableMod 체크 통과 후
\`\`\`

### 배포 스크립트 업데이트

\`deploy-mac.sh\` 가 \`QuackForge.*.dll\` 를 전부 복사하도록 수정 (기존엔 Loader.dll 만).

## Test plan
- [x] \`dotnet build -c Release\` → 0 warn, 0 error, QuackForge.Core.dll 생성
- [x] deploy-mac.sh → 2 DLLs (Core + Loader) 배포
- [x] Duckov 실행 → LogOutput.log 에 \`[Core] QfCore initialized.\` 확인
- [x] QfCore.Initialize 중복 호출 방지 (InvalidOperationException)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)