### PR TITLE
feat(#13): weapon data pipeline + 10 weapon definitions

### DIFF
--- a/QuackForge.sln
+++ b/QuackForge.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Core", "src\QuackForge.Core\QuackForge.Core.csproj", "{02EE985A-1D28-4574-AC4B-460CD9A92254}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Data", "src\QuackForge.Data\QuackForge.Data.csproj", "{C6056E9D-9406-4D95-9A28-F762D9AF893F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,11 +45,24 @@ Global
 		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x64.Build.0 = Release|Any CPU
 		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x86.ActiveCfg = Release|Any CPU
 		{02EE985A-1D28-4574-AC4B-460CD9A92254}.Release|x86.Build.0 = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x64.Build.0 = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{02EE985A-1D28-4574-AC4B-460CD9A92254} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C6056E9D-9406-4D95-9A28-F762D9AF893F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/scripts/deploy-mac.sh
+++ b/scripts/deploy-mac.sh
@@ -55,13 +55,30 @@ deploy() {
     err "Build output missing: $loader"
     exit 1
   fi
+  local duckov_managed="$DUCKOV_DIR/Duckov.app/Contents/Resources/Data/Managed"
   mkdir -p "$PLUGINS_DIR"
   local count=0
-  for dll in "$BUILD_OUTPUT"/QuackForge.*.dll; do
+  for dll in "$BUILD_OUTPUT"/*.dll; do
     [[ -f "$dll" ]] || continue
-    cp "$dll" "$PLUGINS_DIR/"
-    log "deployed → $PLUGINS_DIR/$(basename "$dll")"
-    count=$((count + 1))
+    local base
+    base=$(basename "$dll")
+    case "$base" in
+      QuackForge.*.dll)
+        cp "$dll" "$PLUGINS_DIR/"
+        log "deployed → $base"
+        count=$((count + 1))
+        ;;
+      *)
+        # Ship third-party deps only if the game doesn't already provide them
+        # (avoids type-forwarding conflicts with Mono runtime assemblies).
+        if [[ -f "$duckov_managed/$base" ]]; then
+          continue
+        fi
+        cp "$dll" "$PLUGINS_DIR/"
+        log "dep      → $base"
+        count=$((count + 1))
+        ;;
+    esac
   done
   log "$count DLLs deployed"
 }

--- a/src/QuackForge.Data/QuackForge.Data.csproj
+++ b/src/QuackForge.Data/QuackForge.Data.csproj
@@ -2,27 +2,27 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyName>QuackForge.Loader</AssemblyName>
-    <RootNamespace>QuackForge.Loader</RootNamespace>
+    <AssemblyName>QuackForge.Data</AssemblyName>
+    <RootNamespace>QuackForge.Data</RootNamespace>
     <Version>0.0.1</Version>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <RestoreAdditionalProjectSources>https://nuget.bepinex.dev/v3/index.json</RestoreAdditionalProjectSources>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
-    <PackageReference Include="HarmonyX" Version="2.10.2" />
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\QuackForge.Core\QuackForge.Core.csproj" />
-    <ProjectReference Include="..\QuackForge.Data\QuackForge.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Weapons\Definitions\*.json" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Data/Weapons/Definitions/01_ar_ranger.json
+++ b/src/QuackForge.Data/Weapons/Definitions/01_ar_ranger.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_ar_ranger",
+  "displayName": { "en": "Ranger AR", "ko": "레인저 AR" },
+  "category": "ar",
+  "tier": 2,
+  "baseModel": "weapon_ar_base",
+  "stats": {
+    "damage": 38,
+    "fireRate": 680,
+    "accuracy": 0.82,
+    "recoil": 0.28,
+    "magazineSize": 30,
+    "reloadTime": 2.6,
+    "range": 80
+  },
+  "ammoType": "5.56x45",
+  "weight": 3.4,
+  "price": 9800,
+  "dropRate": 0.04,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_ar_ranger",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 12 },
+      { "itemId": "weapon_part_common", "count": 4 },
+      { "itemId": "gunpowder", "count": 6 }
+    ],
+    "workbenchTier": 1,
+    "craftTime": 90
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/02_ar_duckstorm.json
+++ b/src/QuackForge.Data/Weapons/Definitions/02_ar_duckstorm.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_ar_duckstorm",
+  "displayName": { "en": "Duckstorm AR", "ko": "덕스톰 AR" },
+  "category": "ar",
+  "tier": 4,
+  "baseModel": "weapon_ar_base",
+  "stats": {
+    "damage": 52,
+    "fireRate": 760,
+    "accuracy": 0.74,
+    "recoil": 0.42,
+    "magazineSize": 40,
+    "reloadTime": 3.1,
+    "range": 85
+  },
+  "ammoType": "7.62x39",
+  "weight": 4.1,
+  "price": 22500,
+  "dropRate": 0.008,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_ar_duckstorm",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 22 },
+      { "itemId": "weapon_part_rare", "count": 5 },
+      { "itemId": "gunpowder", "count": 12 }
+    ],
+    "workbenchTier": 2,
+    "craftTime": 160
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/03_ar_silencer_vx.json
+++ b/src/QuackForge.Data/Weapons/Definitions/03_ar_silencer_vx.json
@@ -1,0 +1,31 @@
+{
+  "id": "quackforge_weapon_ar_silencer_vx",
+  "displayName": { "en": "Silencer VX", "ko": "사일렌서 VX" },
+  "category": "ar",
+  "tier": 3,
+  "baseModel": "weapon_ar_base",
+  "stats": {
+    "damage": 42,
+    "fireRate": 620,
+    "accuracy": 0.88,
+    "recoil": 0.22,
+    "magazineSize": 25,
+    "reloadTime": 2.7,
+    "range": 90
+  },
+  "ammoType": "5.56x45",
+  "weight": 3.6,
+  "price": 16400,
+  "dropRate": 0.018,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_ar_silencer_vx",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 14 },
+      { "itemId": "weapon_part_rare", "count": 3 },
+      { "itemId": "suppressor_kit", "count": 1 },
+      { "itemId": "gunpowder", "count": 8 }
+    ],
+    "workbenchTier": 2,
+    "craftTime": 140
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/04_smg_vector_custom.json
+++ b/src/QuackForge.Data/Weapons/Definitions/04_smg_vector_custom.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_smg_vector_custom",
+  "displayName": { "en": "Vector Custom", "ko": "벡터 커스텀" },
+  "category": "smg",
+  "tier": 3,
+  "baseModel": "weapon_smg_base",
+  "stats": {
+    "damage": 32,
+    "fireRate": 1100,
+    "accuracy": 0.72,
+    "recoil": 0.35,
+    "magazineSize": 33,
+    "reloadTime": 2.2,
+    "range": 45
+  },
+  "ammoType": "9mm",
+  "weight": 2.6,
+  "price": 12500,
+  "dropRate": 0.02,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_smg_vector_custom",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 10 },
+      { "itemId": "weapon_part_rare", "count": 3 },
+      { "itemId": "gunpowder", "count": 8 }
+    ],
+    "workbenchTier": 2,
+    "craftTime": 110
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/05_smg_quickdraw.json
+++ b/src/QuackForge.Data/Weapons/Definitions/05_smg_quickdraw.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_smg_quickdraw",
+  "displayName": { "en": "Quickdraw SMG", "ko": "퀵드로우 SMG" },
+  "category": "smg",
+  "tier": 2,
+  "baseModel": "weapon_smg_base",
+  "stats": {
+    "damage": 26,
+    "fireRate": 950,
+    "accuracy": 0.68,
+    "recoil": 0.30,
+    "magazineSize": 25,
+    "reloadTime": 1.6,
+    "range": 40
+  },
+  "ammoType": "9mm",
+  "weight": 2.2,
+  "price": 7200,
+  "dropRate": 0.05,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_smg_quickdraw",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 8 },
+      { "itemId": "weapon_part_common", "count": 3 },
+      { "itemId": "gunpowder", "count": 5 }
+    ],
+    "workbenchTier": 1,
+    "craftTime": 75
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/06_sg_scattergun.json
+++ b/src/QuackForge.Data/Weapons/Definitions/06_sg_scattergun.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_sg_scattergun",
+  "displayName": { "en": "Scattergun", "ko": "스캐터건" },
+  "category": "shotgun",
+  "tier": 2,
+  "baseModel": "weapon_sg_base",
+  "stats": {
+    "damage": 84,
+    "fireRate": 150,
+    "accuracy": 0.58,
+    "recoil": 0.62,
+    "magazineSize": 6,
+    "reloadTime": 3.2,
+    "range": 18
+  },
+  "ammoType": "12ga_buck",
+  "weight": 3.8,
+  "price": 8900,
+  "dropRate": 0.04,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_sg_scattergun",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 10 },
+      { "itemId": "weapon_part_common", "count": 3 },
+      { "itemId": "gunpowder", "count": 7 }
+    ],
+    "workbenchTier": 1,
+    "craftTime": 100
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/07_sg_duckpunch.json
+++ b/src/QuackForge.Data/Weapons/Definitions/07_sg_duckpunch.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_sg_duckpunch",
+  "displayName": { "en": "Duckpunch 12", "ko": "덕펀치 12" },
+  "category": "shotgun",
+  "tier": 4,
+  "baseModel": "weapon_sg_base",
+  "stats": {
+    "damage": 132,
+    "fireRate": 90,
+    "accuracy": 0.52,
+    "recoil": 0.82,
+    "magazineSize": 4,
+    "reloadTime": 4.1,
+    "range": 22
+  },
+  "ammoType": "12ga_slug",
+  "weight": 5.1,
+  "price": 24800,
+  "dropRate": 0.006,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_sg_duckpunch",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 24 },
+      { "itemId": "weapon_part_rare", "count": 6 },
+      { "itemId": "gunpowder", "count": 14 }
+    ],
+    "workbenchTier": 3,
+    "craftTime": 200
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/08_sr_quackshot.json
+++ b/src/QuackForge.Data/Weapons/Definitions/08_sr_quackshot.json
@@ -1,0 +1,31 @@
+{
+  "id": "quackforge_weapon_sr_quackshot",
+  "displayName": { "en": "Quackshot SR", "ko": "쿽샷 SR" },
+  "category": "sniper",
+  "tier": 4,
+  "baseModel": "weapon_sr_base",
+  "stats": {
+    "damage": 165,
+    "fireRate": 55,
+    "accuracy": 0.96,
+    "recoil": 0.55,
+    "magazineSize": 5,
+    "reloadTime": 3.8,
+    "range": 180
+  },
+  "ammoType": "7.62x54r",
+  "weight": 5.4,
+  "price": 32000,
+  "dropRate": 0.005,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_sr_quackshot",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 20 },
+      { "itemId": "weapon_part_rare", "count": 6 },
+      { "itemId": "optic_lens_precision", "count": 1 },
+      { "itemId": "gunpowder", "count": 10 }
+    ],
+    "workbenchTier": 3,
+    "craftTime": 240
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/09_pistol_sidekick.json
+++ b/src/QuackForge.Data/Weapons/Definitions/09_pistol_sidekick.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_pistol_sidekick",
+  "displayName": { "en": "Sidekick", "ko": "사이드킥" },
+  "category": "pistol",
+  "tier": 1,
+  "baseModel": "weapon_pistol_base",
+  "stats": {
+    "damage": 22,
+    "fireRate": 360,
+    "accuracy": 0.78,
+    "recoil": 0.18,
+    "magazineSize": 15,
+    "reloadTime": 1.4,
+    "range": 35
+  },
+  "ammoType": "9mm",
+  "weight": 1.1,
+  "price": 3200,
+  "dropRate": 0.08,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_pistol_sidekick",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 5 },
+      { "itemId": "weapon_part_common", "count": 2 },
+      { "itemId": "gunpowder", "count": 3 }
+    ],
+    "workbenchTier": 1,
+    "craftTime": 45
+  }
+}

--- a/src/QuackForge.Data/Weapons/Definitions/10_pistol_thunderbill.json
+++ b/src/QuackForge.Data/Weapons/Definitions/10_pistol_thunderbill.json
@@ -1,0 +1,30 @@
+{
+  "id": "quackforge_weapon_pistol_thunderbill",
+  "displayName": { "en": "Thunderbill .50", "ko": "선더빌 .50" },
+  "category": "pistol",
+  "tier": 4,
+  "baseModel": "weapon_pistol_base",
+  "stats": {
+    "damage": 86,
+    "fireRate": 140,
+    "accuracy": 0.70,
+    "recoil": 0.72,
+    "magazineSize": 7,
+    "reloadTime": 2.2,
+    "range": 42
+  },
+  "ammoType": "50ae",
+  "weight": 2.4,
+  "price": 18600,
+  "dropRate": 0.01,
+  "craftingRecipe": {
+    "blueprintId": "quackforge_blueprint_pistol_thunderbill",
+    "materials": [
+      { "itemId": "scrap_metal", "count": 14 },
+      { "itemId": "weapon_part_rare", "count": 4 },
+      { "itemId": "gunpowder", "count": 9 }
+    ],
+    "workbenchTier": 2,
+    "craftTime": 135
+  }
+}

--- a/src/QuackForge.Data/Weapons/WeaponDefinition.cs
+++ b/src/QuackForge.Data/Weapons/WeaponDefinition.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace QuackForge.Data.Weapons
+{
+    public sealed class WeaponDefinition
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("displayName")]
+        public Dictionary<string, string> DisplayName { get; set; } = new();
+
+        [JsonPropertyName("category")]
+        public string Category { get; set; } = "";
+
+        [JsonPropertyName("tier")]
+        public int Tier { get; set; }
+
+        [JsonPropertyName("baseModel")]
+        public string BaseModel { get; set; } = "";
+
+        [JsonPropertyName("stats")]
+        public WeaponStats Stats { get; set; } = new();
+
+        [JsonPropertyName("ammoType")]
+        public string AmmoType { get; set; } = "";
+
+        [JsonPropertyName("weight")]
+        public float Weight { get; set; }
+
+        [JsonPropertyName("price")]
+        public int Price { get; set; }
+
+        [JsonPropertyName("dropRate")]
+        public float DropRate { get; set; }
+
+        [JsonPropertyName("craftingRecipe")]
+        public CraftingRecipe? CraftingRecipe { get; set; }
+    }
+
+    public sealed class WeaponStats
+    {
+        [JsonPropertyName("damage")] public float Damage { get; set; }
+        [JsonPropertyName("fireRate")] public float FireRate { get; set; }
+        [JsonPropertyName("accuracy")] public float Accuracy { get; set; }
+        [JsonPropertyName("recoil")] public float Recoil { get; set; }
+        [JsonPropertyName("magazineSize")] public int MagazineSize { get; set; }
+        [JsonPropertyName("reloadTime")] public float ReloadTime { get; set; }
+        [JsonPropertyName("range")] public float Range { get; set; }
+    }
+
+    public sealed class CraftingRecipe
+    {
+        [JsonPropertyName("blueprintId")] public string BlueprintId { get; set; } = "";
+        [JsonPropertyName("materials")] public List<MaterialEntry> Materials { get; set; } = new();
+        [JsonPropertyName("workbenchTier")] public int WorkbenchTier { get; set; }
+        [JsonPropertyName("craftTime")] public float CraftTime { get; set; }
+    }
+
+    public sealed class MaterialEntry
+    {
+        [JsonPropertyName("itemId")] public string ItemId { get; set; } = "";
+        [JsonPropertyName("count")] public int Count { get; set; }
+    }
+}

--- a/src/QuackForge.Data/Weapons/WeaponRegistry.cs
+++ b/src/QuackForge.Data/Weapons/WeaponRegistry.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using QuackForge.Core.Logging;
+
+namespace QuackForge.Data.Weapons
+{
+    public sealed class WeaponRegistry
+    {
+        public const string IdPrefix = "quackforge_weapon_";
+        private const string ResourceNamespace = "QuackForge.Data.Weapons.Definitions.";
+
+        private readonly Dictionary<string, WeaponDefinition> _cache = new(StringComparer.Ordinal);
+        private readonly IQfLog _log = QfLogger.For("Data.Weapons");
+
+        public IReadOnlyCollection<WeaponDefinition> All => _cache.Values;
+        public int Count => _cache.Count;
+
+        public bool TryGet(string id, out WeaponDefinition definition)
+        {
+            if (_cache.TryGetValue(id, out var found))
+            {
+                definition = found;
+                return true;
+            }
+            definition = default!;
+            return false;
+        }
+
+        public int LoadAll()
+        {
+            _cache.Clear();
+            var assembly = typeof(WeaponRegistry).Assembly;
+            var resourceNames = assembly.GetManifestResourceNames()
+                .Where(n => n.StartsWith(ResourceNamespace, StringComparison.Ordinal) && n.EndsWith(".json", StringComparison.Ordinal))
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            foreach (var resource in resourceNames)
+            {
+                try
+                {
+                    var def = LoadDefinition(assembly, resource, options);
+                    Validate(def, resource);
+                    if (_cache.ContainsKey(def.Id))
+                    {
+                        _log.Error($"duplicate weapon id '{def.Id}' (resource: {resource}) — skipped");
+                        continue;
+                    }
+                    _cache[def.Id] = def;
+                    _log.Debug($"loaded weapon '{def.Id}' ({def.Category} tier {def.Tier})");
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"failed to load weapon resource {resource}", ex);
+                }
+            }
+            _log.Info($"weapon registry ready — {_cache.Count} entries from {resourceNames.Length} resources.");
+            return _cache.Count;
+        }
+
+        private static WeaponDefinition LoadDefinition(Assembly assembly, string resource, JsonSerializerOptions options)
+        {
+            using var stream = assembly.GetManifestResourceStream(resource)
+                               ?? throw new InvalidOperationException($"resource stream null for {resource}");
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            var def = JsonSerializer.Deserialize<WeaponDefinition>(json, options)
+                      ?? throw new InvalidDataException($"deserialized to null: {resource}");
+            return def;
+        }
+
+        private static void Validate(WeaponDefinition def, string resource)
+        {
+            if (string.IsNullOrWhiteSpace(def.Id))
+                throw new InvalidDataException($"{resource}: id missing");
+            if (!def.Id.StartsWith(IdPrefix, StringComparison.Ordinal))
+                throw new InvalidDataException($"{resource}: id '{def.Id}' must start with '{IdPrefix}'");
+            if (string.IsNullOrWhiteSpace(def.Category))
+                throw new InvalidDataException($"{resource}: category missing for '{def.Id}'");
+            if (def.Stats == null)
+                throw new InvalidDataException($"{resource}: stats missing for '{def.Id}'");
+        }
+    }
+}

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using QuackForge.Core;
+using QuackForge.Data.Weapons;
 
 namespace QuackForge.Loader
 {
@@ -14,6 +15,7 @@ namespace QuackForge.Loader
         public const string PluginVersion = "0.0.1";
 
         public static ManualLogSource Log { get; private set; } = null!;
+        public static WeaponRegistry Weapons { get; private set; } = null!;
 
         private Harmony _harmony = null!;
         private ConfigEntry<bool> _enableMod = null!;
@@ -35,6 +37,9 @@ namespace QuackForge.Loader
             }
 
             QfCore.Initialize(Log, Config);
+
+            Weapons = new WeaponRegistry();
+            Weapons.LoadAll();
 
             _harmony = new Harmony(PluginGuid);
             _harmony.PatchAll();


### PR DESCRIPTION
## Summary
PRD §5.4.1 무기 데이터 스키마 구현 + 10종 무기 JSON 카탈로그 + 런타임 로더.

## 신규 프로젝트 \`QuackForge.Data\`
- \`WeaponDefinition\` (PRD 스키마 1:1 매핑)
- \`WeaponRegistry.LoadAll()\`: embedded resource 스캔 → System.Text.Json 역직렬화 → 검증 → 캐시
- 검증: \`quackforge_weapon_\` prefix 강제, 필수 필드, ID 중복 거부

## 10종 카탈로그
| 카테고리 | 무기 | tier |
|---|---|---|
| AR | ar_ranger, ar_duckstorm, ar_silencer_vx | 2/4/3 |
| SMG | smg_vector_custom, smg_quickdraw | 3/2 |
| Shotgun | sg_scattergun, sg_duckpunch | 2/4 |
| Sniper | sr_quackshot | 4 |
| Pistol | pistol_sidekick, pistol_thunderbill | 1/4 |

## 런타임 검증
\`\`\`
[Info :QuackForge] [Core] QfCore initialized.
[Info :QuackForge] [Data.Weapons] weapon registry ready — 10 entries from 10 resources.
[Info :QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.0.1)
\`\`\`

## 배포 스크립트 개선
\`deploy-mac.sh\`: QuackForge.*.dll + 게임이 제공하지 않는 추이 DLL 만 배포 (Mono 런타임과 타입 충돌 회피). System.Text.Json 8.0.5 및 필수 deps 총 20개 동봉.

## ⚠️ 미완료 — \"콘솔 스폰 확인\" 항목
T1.2 역공학 결과, PRD 가정한 \`Workbench.GetAvailableRecipes\` Harmony 패치 경로는 실제 게임 API 와 다름. 실 게임은:
- \`CraftingFormulaCollection\` (ScriptableObject) 에서 formula 등록
- \`Item\` 은 Unity **Prefab** (GameObject + ItemSetting_Gun 컴포넌트)
- 데이터-only 로는 Prefab 생성 불가

→ **Part A (공식 Mod API AssetBundle 빌드)** 경로 실증 후 별도 이슈에서 injection 해결 권장.

## Test plan
- [x] \`dotnet build -c Release\` — 0 warn, 0 error
- [x] \`deploy-mac.sh\` 20 DLLs 배포
- [x] Duckov 런타임 10/10 무기 로드
- [ ] 게임 내 실제 스폰 확인 (AssetBundle 경로, 후속 이슈)

Refs #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)