### PR TITLE
feat(#14): armor data pipeline + 5 armor definitions (build-oriented)

### DIFF
--- a/src/QuackForge.Data/Armors/ArmorDefinition.cs
+++ b/src/QuackForge.Data/Armors/ArmorDefinition.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace QuackForge.Data.Armors
+{
+    public sealed class ArmorDefinition
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("displayName")]
+        public Dictionary<string, string> DisplayName { get; set; } = new();
+
+        [JsonPropertyName("slot")]
+        public string Slot { get; set; } = "";
+
+        [JsonPropertyName("tier")]
+        public int Tier { get; set; }
+
+        [JsonPropertyName("baseModel")]
+        public string BaseModel { get; set; } = "";
+
+        [JsonPropertyName("stats")]
+        public ArmorStats Stats { get; set; } = new();
+
+        [JsonPropertyName("durability")]
+        public int Durability { get; set; }
+
+        [JsonPropertyName("repairCost")]
+        public int RepairCost { get; set; }
+    }
+
+    public sealed class ArmorStats
+    {
+        [JsonPropertyName("protection")] public float Protection { get; set; }
+        [JsonPropertyName("penetrationResistance")] public float PenetrationResistance { get; set; }
+        [JsonPropertyName("weightPenalty")] public float WeightPenalty { get; set; }
+
+        // 음수 허용 (= 이동 보너스) — PRD §5.4.2
+        [JsonPropertyName("movementPenalty")] public float MovementPenalty { get; set; }
+
+        [JsonPropertyName("staminaBonus")] public float StaminaBonus { get; set; }
+    }
+}

--- a/src/QuackForge.Data/Armors/ArmorRegistry.cs
+++ b/src/QuackForge.Data/Armors/ArmorRegistry.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using QuackForge.Core.Logging;
+
+namespace QuackForge.Data.Armors
+{
+    public sealed class ArmorRegistry
+    {
+        public const string IdPrefix = "quackforge_armor_";
+        private const string ResourceNamespace = "QuackForge.Data.Armors.Definitions.";
+
+        private readonly Dictionary<string, ArmorDefinition> _cache = new(StringComparer.Ordinal);
+        private readonly IQfLog _log = QfLogger.For("Data.Armors");
+
+        public IReadOnlyCollection<ArmorDefinition> All => _cache.Values;
+        public int Count => _cache.Count;
+
+        public bool TryGet(string id, out ArmorDefinition definition)
+        {
+            if (_cache.TryGetValue(id, out var found))
+            {
+                definition = found;
+                return true;
+            }
+            definition = default!;
+            return false;
+        }
+
+        public int LoadAll()
+        {
+            _cache.Clear();
+            var assembly = typeof(ArmorRegistry).Assembly;
+            var resourceNames = assembly.GetManifestResourceNames()
+                .Where(n => n.StartsWith(ResourceNamespace, StringComparison.Ordinal) && n.EndsWith(".json", StringComparison.Ordinal))
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            foreach (var resource in resourceNames)
+            {
+                try
+                {
+                    var def = LoadDefinition(assembly, resource, options);
+                    Validate(def, resource);
+                    if (_cache.ContainsKey(def.Id))
+                    {
+                        _log.Error($"duplicate armor id '{def.Id}' (resource: {resource}) — skipped");
+                        continue;
+                    }
+                    _cache[def.Id] = def;
+                    _log.Debug($"loaded armor '{def.Id}' ({def.Slot} tier {def.Tier})");
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"failed to load armor resource {resource}", ex);
+                }
+            }
+            _log.Info($"armor registry ready — {_cache.Count} entries from {resourceNames.Length} resources.");
+            return _cache.Count;
+        }
+
+        private static ArmorDefinition LoadDefinition(Assembly assembly, string resource, JsonSerializerOptions options)
+        {
+            using var stream = assembly.GetManifestResourceStream(resource)
+                               ?? throw new InvalidOperationException($"resource stream null for {resource}");
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            var def = JsonSerializer.Deserialize<ArmorDefinition>(json, options)
+                      ?? throw new InvalidDataException($"deserialized to null: {resource}");
+            return def;
+        }
+
+        private static void Validate(ArmorDefinition def, string resource)
+        {
+            if (string.IsNullOrWhiteSpace(def.Id))
+                throw new InvalidDataException($"{resource}: id missing");
+            if (!def.Id.StartsWith(IdPrefix, StringComparison.Ordinal))
+                throw new InvalidDataException($"{resource}: id '{def.Id}' must start with '{IdPrefix}'");
+            if (string.IsNullOrWhiteSpace(def.Slot))
+                throw new InvalidDataException($"{resource}: slot missing for '{def.Id}'");
+            if (def.Stats == null)
+                throw new InvalidDataException($"{resource}: stats missing for '{def.Id}'");
+        }
+    }
+}

--- a/src/QuackForge.Data/Armors/Definitions/01_chest_stealth_vest.json
+++ b/src/QuackForge.Data/Armors/Definitions/01_chest_stealth_vest.json
@@ -1,0 +1,16 @@
+{
+  "id": "quackforge_armor_chest_stealth_vest",
+  "displayName": { "en": "Stealth Vest", "ko": "은폐 조끼" },
+  "slot": "chest",
+  "tier": 3,
+  "baseModel": "armor_tactical_vest",
+  "stats": {
+    "protection": 45,
+    "penetrationResistance": 0.6,
+    "weightPenalty": 1.2,
+    "movementPenalty": -0.05,
+    "staminaBonus": 0.10
+  },
+  "durability": 180,
+  "repairCost": 850
+}

--- a/src/QuackForge.Data/Armors/Definitions/02_chest_bulwark_plate.json
+++ b/src/QuackForge.Data/Armors/Definitions/02_chest_bulwark_plate.json
@@ -1,0 +1,16 @@
+{
+  "id": "quackforge_armor_chest_bulwark_plate",
+  "displayName": { "en": "Bulwark Plate", "ko": "벌워크 플레이트" },
+  "slot": "chest",
+  "tier": 4,
+  "baseModel": "armor_heavy_plate",
+  "stats": {
+    "protection": 92,
+    "penetrationResistance": 0.85,
+    "weightPenalty": 5.4,
+    "movementPenalty": 0.18,
+    "staminaBonus": -0.08
+  },
+  "durability": 320,
+  "repairCost": 2100
+}

--- a/src/QuackForge.Data/Armors/Definitions/03_head_nightowl_helm.json
+++ b/src/QuackForge.Data/Armors/Definitions/03_head_nightowl_helm.json
@@ -1,0 +1,16 @@
+{
+  "id": "quackforge_armor_head_nightowl_helm",
+  "displayName": { "en": "Nightowl Helm", "ko": "나이트아울 헬름" },
+  "slot": "head",
+  "tier": 3,
+  "baseModel": "armor_tactical_helmet",
+  "stats": {
+    "protection": 62,
+    "penetrationResistance": 0.55,
+    "weightPenalty": 0.9,
+    "movementPenalty": 0.02,
+    "staminaBonus": 0.0
+  },
+  "durability": 140,
+  "repairCost": 720
+}

--- a/src/QuackForge.Data/Armors/Definitions/04_chest_featherweight.json
+++ b/src/QuackForge.Data/Armors/Definitions/04_chest_featherweight.json
@@ -1,0 +1,16 @@
+{
+  "id": "quackforge_armor_chest_featherweight",
+  "displayName": { "en": "Featherweight Wrap", "ko": "페더웨이트 랩" },
+  "slot": "chest",
+  "tier": 2,
+  "baseModel": "armor_light_vest",
+  "stats": {
+    "protection": 22,
+    "penetrationResistance": 0.30,
+    "weightPenalty": 0.4,
+    "movementPenalty": -0.12,
+    "staminaBonus": 0.22
+  },
+  "durability": 110,
+  "repairCost": 380
+}

--- a/src/QuackForge.Data/Armors/Definitions/05_backpack_scavenger.json
+++ b/src/QuackForge.Data/Armors/Definitions/05_backpack_scavenger.json
@@ -1,0 +1,16 @@
+{
+  "id": "quackforge_armor_backpack_scavenger",
+  "displayName": { "en": "Scavenger's Rig", "ko": "스캐빈저 리그" },
+  "slot": "backpack",
+  "tier": 3,
+  "baseModel": "armor_utility_rig",
+  "stats": {
+    "protection": 12,
+    "penetrationResistance": 0.15,
+    "weightPenalty": 1.8,
+    "movementPenalty": 0.04,
+    "staminaBonus": 0.08
+  },
+  "durability": 200,
+  "repairCost": 640
+}

--- a/src/QuackForge.Data/QuackForge.Data.csproj
+++ b/src/QuackForge.Data/QuackForge.Data.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Weapons\Definitions\*.json" />
+    <EmbeddedResource Include="Armors\Definitions\*.json" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using QuackForge.Core;
+using QuackForge.Data.Armors;
 using QuackForge.Data.Weapons;
 
 namespace QuackForge.Loader
@@ -16,6 +17,7 @@ namespace QuackForge.Loader
 
         public static ManualLogSource Log { get; private set; } = null!;
         public static WeaponRegistry Weapons { get; private set; } = null!;
+        public static ArmorRegistry Armors { get; private set; } = null!;
 
         private Harmony _harmony = null!;
         private ConfigEntry<bool> _enableMod = null!;
@@ -40,6 +42,9 @@ namespace QuackForge.Loader
 
             Weapons = new WeaponRegistry();
             Weapons.LoadAll();
+
+            Armors = new ArmorRegistry();
+            Armors.LoadAll();
 
             _harmony = new Harmony(PluginGuid);
             _harmony.PatchAll();


### PR DESCRIPTION
## Summary
PRD §5.4.2 방어구 데이터 스키마 + 5종 카탈로그. 무기와 동일 패턴 (embedded JSON + System.Text.Json + Registry).

## 5종 카탈로그 — 빌드 지향성

| 방어구 | slot | tier | 특성 | movement | stamina | protection |
|---|---|---|---|---|---|---|
| Featherweight Wrap | chest | 2 | 민첩 | **-0.12** | +0.22 | 22 |
| Stealth Vest | chest | 3 | 민첩+ | -0.05 | +0.10 | 45 |
| Bulwark Plate | chest | 4 | 탱크 | +0.18 | -0.08 | **92** |
| Nightowl Helm | head | 3 | 밸런스 | +0.02 | 0 | 62 |
| Scavenger's Rig | backpack | 3 | 유틸 | +0.04 | +0.08 | 12 |

**movementPenalty 음수 허용** (PRD 설계 결정 반영) → 민첩 빌드가 이동 속도 보너스로 탱크 빌드와 차별화.

## 런타임 검증
\`\`\`
[Info :QuackForge] [Data.Weapons] weapon registry ready — 10 entries from 10 resources.
[Info :QuackForge] [Data.Armors] armor registry ready — 5 entries from 5 resources.
[Info :QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.0.1)
\`\`\`

## ⚠️ 미완료
"게임 내 장착 확인" Done 기준은 #13 과 동일하게 AssetBundle 경로 (#65) 후속 이슈로 이관. 현 PR 은 **데이터 파이프라인 + 빌드 시스템 설계** 완료 기준.

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] Mac Duckov 런타임 5/5 방어구 로드 확인
- [x] movementPenalty 음수 값 (Featherweight -0.12) 정상 역직렬화
- [ ] 게임 내 장착 확인 (AssetBundle 경로, #65 후속)

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)