### PR TITLE
feat(#15): Blueprint system with unlock state & event bus

### DIFF
--- a/src/QuackForge.Data/Blueprints/BlueprintDefinition.cs
+++ b/src/QuackForge.Data/Blueprints/BlueprintDefinition.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace QuackForge.Data.Blueprints
+{
+    public sealed class BlueprintDefinition
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("displayName")]
+        public Dictionary<string, string> DisplayName { get; set; } = new();
+
+        [JsonPropertyName("unlocksWeapon")]
+        public string? UnlocksWeapon { get; set; }
+
+        [JsonPropertyName("unlocksArmor")]
+        public string? UnlocksArmor { get; set; }
+
+        [JsonPropertyName("unlockConditions")]
+        public UnlockConditions Conditions { get; set; } = new();
+
+        // true = 1회용 (제작 시 소모), false = 영구 해금
+        [JsonPropertyName("consumeOnUse")]
+        public bool ConsumeOnUse { get; set; }
+    }
+
+    public sealed class UnlockConditions
+    {
+        [JsonPropertyName("minPlayerLevel")] public int MinPlayerLevel { get; set; }
+        [JsonPropertyName("dropSources")] public List<DropSource> DropSources { get; set; } = new();
+    }
+
+    public sealed class DropSource
+    {
+        [JsonPropertyName("enemy")] public string? Enemy { get; set; }
+        [JsonPropertyName("challenge")] public string? Challenge { get; set; }
+        [JsonPropertyName("chance")] public float Chance { get; set; }
+        [JsonPropertyName("guaranteed")] public bool Guaranteed { get; set; }
+    }
+}

--- a/src/QuackForge.Data/Blueprints/BlueprintEvents.cs
+++ b/src/QuackForge.Data/Blueprints/BlueprintEvents.cs
@@ -1,0 +1,14 @@
+namespace QuackForge.Data.Blueprints
+{
+    public readonly struct BlueprintUnlockedEvent
+    {
+        public string BlueprintId { get; }
+        public BlueprintUnlockedEvent(string blueprintId) => BlueprintId = blueprintId;
+    }
+
+    public readonly struct BlueprintConsumedEvent
+    {
+        public string BlueprintId { get; }
+        public BlueprintConsumedEvent(string blueprintId) => BlueprintId = blueprintId;
+    }
+}

--- a/src/QuackForge.Data/Blueprints/BlueprintRegistry.cs
+++ b/src/QuackForge.Data/Blueprints/BlueprintRegistry.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using QuackForge.Core.Events;
+using QuackForge.Core.Logging;
+using QuackForge.Core.Save;
+
+namespace QuackForge.Data.Blueprints
+{
+    public sealed class BlueprintRegistry
+    {
+        public const string IdPrefix = "quackforge_blueprint_";
+        private const string ResourceNamespace = "QuackForge.Data.Blueprints.Definitions.";
+        private const string SaveKey = "QuackForge.Blueprints.Unlocked";
+
+        private readonly Dictionary<string, BlueprintDefinition> _cache = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _unlocked = new(StringComparer.Ordinal);
+        private readonly IQfLog _log = QfLogger.For("Data.Blueprints");
+        private readonly QfEventBus _bus;
+        private readonly QfSaveContext _save;
+
+        public BlueprintRegistry(QfEventBus bus, QfSaveContext save)
+        {
+            _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+            _save = save ?? throw new ArgumentNullException(nameof(save));
+        }
+
+        public IReadOnlyCollection<BlueprintDefinition> All => _cache.Values;
+        public IReadOnlyCollection<string> UnlockedIds => _unlocked;
+        public int Count => _cache.Count;
+
+        public bool TryGet(string id, out BlueprintDefinition definition)
+        {
+            if (_cache.TryGetValue(id, out var found))
+            {
+                definition = found;
+                return true;
+            }
+            definition = default!;
+            return false;
+        }
+
+        public bool IsUnlocked(string id) => _unlocked.Contains(id);
+
+        public bool Unlock(string id)
+        {
+            if (!_cache.ContainsKey(id))
+            {
+                _log.Warn($"Unlock called with unknown blueprint '{id}'");
+                return false;
+            }
+            if (!_unlocked.Add(id)) return false;
+            Persist();
+            _log.Info($"blueprint unlocked: {id}");
+            _bus.Publish(new BlueprintUnlockedEvent(id));
+            return true;
+        }
+
+        // 1회용 블루프린트 제작 시 소모
+        public bool Consume(string id)
+        {
+            if (!_cache.TryGetValue(id, out var def))
+            {
+                _log.Warn($"Consume called with unknown blueprint '{id}'");
+                return false;
+            }
+            if (!def.ConsumeOnUse)
+            {
+                _log.Debug($"Consume skipped (permanent blueprint): {id}");
+                return false;
+            }
+            if (!_unlocked.Remove(id)) return false;
+            Persist();
+            _log.Info($"blueprint consumed: {id}");
+            _bus.Publish(new BlueprintConsumedEvent(id));
+            return true;
+        }
+
+        public int LoadAll()
+        {
+            _cache.Clear();
+            var assembly = typeof(BlueprintRegistry).Assembly;
+            var resourceNames = assembly.GetManifestResourceNames()
+                .Where(n => n.StartsWith(ResourceNamespace, StringComparison.Ordinal) && n.EndsWith(".json", StringComparison.Ordinal))
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            foreach (var resource in resourceNames)
+            {
+                try
+                {
+                    var def = LoadDefinition(assembly, resource, options);
+                    Validate(def, resource);
+                    if (_cache.ContainsKey(def.Id))
+                    {
+                        _log.Error($"duplicate blueprint id '{def.Id}' (resource: {resource}) — skipped");
+                        continue;
+                    }
+                    _cache[def.Id] = def;
+                    _log.Debug($"loaded blueprint '{def.Id}' → weapon={def.UnlocksWeapon ?? "-"} armor={def.UnlocksArmor ?? "-"}");
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"failed to load blueprint resource {resource}", ex);
+                }
+            }
+
+            RestoreUnlocked();
+            _log.Info($"blueprint registry ready — {_cache.Count} entries, {_unlocked.Count} unlocked.");
+            return _cache.Count;
+        }
+
+        private static BlueprintDefinition LoadDefinition(Assembly assembly, string resource, JsonSerializerOptions options)
+        {
+            using var stream = assembly.GetManifestResourceStream(resource)
+                               ?? throw new InvalidOperationException($"resource stream null for {resource}");
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            return JsonSerializer.Deserialize<BlueprintDefinition>(json, options)
+                   ?? throw new InvalidDataException($"deserialized to null: {resource}");
+        }
+
+        private static void Validate(BlueprintDefinition def, string resource)
+        {
+            if (string.IsNullOrWhiteSpace(def.Id))
+                throw new InvalidDataException($"{resource}: id missing");
+            if (!def.Id.StartsWith(IdPrefix, StringComparison.Ordinal))
+                throw new InvalidDataException($"{resource}: id '{def.Id}' must start with '{IdPrefix}'");
+            if (string.IsNullOrWhiteSpace(def.UnlocksWeapon) && string.IsNullOrWhiteSpace(def.UnlocksArmor))
+                throw new InvalidDataException($"{resource}: must unlock weapon or armor ({def.Id})");
+        }
+
+        private void RestoreUnlocked()
+        {
+            _unlocked.Clear();
+            if (_save.TryGet<HashSet<string>>(SaveKey, out var saved))
+            {
+                foreach (var id in saved)
+                {
+                    if (_cache.ContainsKey(id)) _unlocked.Add(id);
+                }
+            }
+        }
+
+        private void Persist()
+        {
+            _save.Set(SaveKey, new HashSet<string>(_unlocked, StringComparer.Ordinal));
+        }
+    }
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/01_ar_ranger.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/01_ar_ranger.json
@@ -1,0 +1,10 @@
+{
+  "id": "quackforge_blueprint_ar_ranger",
+  "displayName": { "en": "Blueprint: Ranger AR", "ko": "도면: 레인저 AR" },
+  "unlocksWeapon": "quackforge_weapon_ar_ranger",
+  "unlockConditions": {
+    "minPlayerLevel": 3,
+    "dropSources": []
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/02_ar_duckstorm.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/02_ar_duckstorm.json
@@ -1,0 +1,13 @@
+{
+  "id": "quackforge_blueprint_ar_duckstorm",
+  "displayName": { "en": "Blueprint: Duckstorm AR", "ko": "도면: 덕스톰 AR" },
+  "unlocksWeapon": "quackforge_weapon_ar_duckstorm",
+  "unlockConditions": {
+    "minPlayerLevel": 18,
+    "dropSources": [
+      { "enemy": "boss_warehouse_overlord", "chance": 0.12 },
+      { "challenge": "boss_rush_warehouse", "guaranteed": true }
+    ]
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/03_ar_silencer_vx.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/03_ar_silencer_vx.json
@@ -1,0 +1,12 @@
+{
+  "id": "quackforge_blueprint_ar_silencer_vx",
+  "displayName": { "en": "Blueprint: Silencer VX", "ko": "도면: 사일렌서 VX" },
+  "unlocksWeapon": "quackforge_weapon_ar_silencer_vx",
+  "unlockConditions": {
+    "minPlayerLevel": 12,
+    "dropSources": [
+      { "enemy": "boss_farm_king", "chance": 0.15 }
+    ]
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/04_smg_vector_custom.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/04_smg_vector_custom.json
@@ -1,0 +1,13 @@
+{
+  "id": "quackforge_blueprint_smg_vector_custom",
+  "displayName": { "en": "Blueprint: Vector Custom", "ko": "도면: 벡터 커스텀" },
+  "unlocksWeapon": "quackforge_weapon_smg_vector_custom",
+  "unlockConditions": {
+    "minPlayerLevel": 10,
+    "dropSources": [
+      { "enemy": "boss_farm_king", "chance": 0.15 },
+      { "challenge": "boss_rush_farm", "guaranteed": true }
+    ]
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/05_smg_quickdraw.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/05_smg_quickdraw.json
@@ -1,0 +1,10 @@
+{
+  "id": "quackforge_blueprint_smg_quickdraw",
+  "displayName": { "en": "Blueprint: Quickdraw SMG", "ko": "도면: 퀵드로우 SMG" },
+  "unlocksWeapon": "quackforge_weapon_smg_quickdraw",
+  "unlockConditions": {
+    "minPlayerLevel": 4,
+    "dropSources": []
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/06_sg_scattergun.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/06_sg_scattergun.json
@@ -1,0 +1,10 @@
+{
+  "id": "quackforge_blueprint_sg_scattergun",
+  "displayName": { "en": "Blueprint: Scattergun", "ko": "도면: 스캐터건" },
+  "unlocksWeapon": "quackforge_weapon_sg_scattergun",
+  "unlockConditions": {
+    "minPlayerLevel": 6,
+    "dropSources": []
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/07_sg_duckpunch.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/07_sg_duckpunch.json
@@ -1,0 +1,13 @@
+{
+  "id": "quackforge_blueprint_sg_duckpunch",
+  "displayName": { "en": "Blueprint: Duckpunch 12", "ko": "도면: 덕펀치 12" },
+  "unlocksWeapon": "quackforge_weapon_sg_duckpunch",
+  "unlockConditions": {
+    "minPlayerLevel": 22,
+    "dropSources": [
+      { "enemy": "boss_depot_titan", "chance": 0.10 },
+      { "challenge": "boss_rush_depot", "guaranteed": true }
+    ]
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/08_sr_quackshot.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/08_sr_quackshot.json
@@ -1,0 +1,13 @@
+{
+  "id": "quackforge_blueprint_sr_quackshot",
+  "displayName": { "en": "Blueprint: Quackshot SR", "ko": "도면: 쿽샷 SR" },
+  "unlocksWeapon": "quackforge_weapon_sr_quackshot",
+  "unlockConditions": {
+    "minPlayerLevel": 20,
+    "dropSources": [
+      { "enemy": "boss_cliff_sentinel", "chance": 0.08 },
+      { "challenge": "boss_rush_cliff", "guaranteed": true }
+    ]
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/09_pistol_sidekick.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/09_pistol_sidekick.json
@@ -1,0 +1,10 @@
+{
+  "id": "quackforge_blueprint_pistol_sidekick",
+  "displayName": { "en": "Blueprint: Sidekick", "ko": "도면: 사이드킥" },
+  "unlocksWeapon": "quackforge_weapon_pistol_sidekick",
+  "unlockConditions": {
+    "minPlayerLevel": 1,
+    "dropSources": []
+  },
+  "consumeOnUse": false
+}

--- a/src/QuackForge.Data/Blueprints/Definitions/10_pistol_thunderbill.json
+++ b/src/QuackForge.Data/Blueprints/Definitions/10_pistol_thunderbill.json
@@ -1,0 +1,12 @@
+{
+  "id": "quackforge_blueprint_pistol_thunderbill",
+  "displayName": { "en": "Blueprint: Thunderbill .50", "ko": "도면: 선더빌 .50" },
+  "unlocksWeapon": "quackforge_weapon_pistol_thunderbill",
+  "unlockConditions": {
+    "minPlayerLevel": 15,
+    "dropSources": [
+      { "enemy": "boss_subway_baron", "chance": 0.14 }
+    ]
+  },
+  "consumeOnUse": true
+}

--- a/src/QuackForge.Data/QuackForge.Data.csproj
+++ b/src/QuackForge.Data/QuackForge.Data.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Weapons\Definitions\*.json" />
     <EmbeddedResource Include="Armors\Definitions\*.json" />
+    <EmbeddedResource Include="Blueprints\Definitions\*.json" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -4,6 +4,7 @@ using BepInEx.Logging;
 using HarmonyLib;
 using QuackForge.Core;
 using QuackForge.Data.Armors;
+using QuackForge.Data.Blueprints;
 using QuackForge.Data.Weapons;
 
 namespace QuackForge.Loader
@@ -18,6 +19,7 @@ namespace QuackForge.Loader
         public static ManualLogSource Log { get; private set; } = null!;
         public static WeaponRegistry Weapons { get; private set; } = null!;
         public static ArmorRegistry Armors { get; private set; } = null!;
+        public static BlueprintRegistry Blueprints { get; private set; } = null!;
 
         private Harmony _harmony = null!;
         private ConfigEntry<bool> _enableMod = null!;
@@ -45,6 +47,10 @@ namespace QuackForge.Loader
 
             Armors = new ArmorRegistry();
             Armors.LoadAll();
+
+            var core = QfCore.Instance!;
+            Blueprints = new BlueprintRegistry(core.Events, core.Save);
+            Blueprints.LoadAll();
 
             _harmony = new Harmony(PluginGuid);
             _harmony.PatchAll();


### PR DESCRIPTION
## Summary
PRD §5.4.3 도면 시스템 구현. 10개 도면 (각 무기 1:1 대응), 해금 상태 지속, 이벤트 발행.

## Components

| 타입 | 역할 |
|---|---|
| \`BlueprintDefinition\` | 스키마 POCO (PRD §5.4.3) |
| \`UnlockConditions\` / \`DropSource\` | 해금 조건 |
| \`BlueprintRegistry\` | embedded JSON 로드, 해금 상태 관리, 제작 시 소모 |
| \`BlueprintUnlockedEvent\` / \`BlueprintConsumedEvent\` | QfEventBus 발행 이벤트 |

### API 핵심
\`\`\`csharp
Plugin.Blueprints.Unlock("quackforge_blueprint_smg_vector_custom");
Plugin.Blueprints.IsUnlocked(id);
Plugin.Blueprints.Consume(id);  // consumeOnUse=true 만 실제 소모
\`\`\`

해금 상태는 \`QfSaveContext\` 에 \`QuackForge.Blueprints.Unlocked\` 키로 persist.

## 10개 도면 티어링

| 티어 | 블루프린트 | 해금 조건 |
|---|---|---|
| 시작 | pistol_sidekick | Lv 1 |
| 저레벨 | ar_ranger / smg_quickdraw / sg_scattergun | Lv 3-6 |
| 중견 | smg_vector_custom / ar_silencer_vx | Lv 10-12, 보스 드랍 |
| 상위 | pistol_thunderbill (1회용) | Lv 15, boss_subway_baron |
| 엔드게임 | ar_duckstorm / sr_quackshot / sg_duckpunch | Lv 18-22, 챌린지 guaranteed |

\`consumeOnUse=true\` 플래그 1개 (pistol_thunderbill) 포함 → 1회용 해금 동작 검증 경로 확보.

## Phase 2/4 연계 포인트

- Phase 2 (레벨링): \`EXPManager.onLevelChanged\` 훅 → \`Blueprints.All.Where(b => player.Level >= b.Conditions.MinPlayerLevel).Select(b => Blueprints.Unlock(b.Id))\`
- Phase 4 (챌린지): 보스 드랍 판정 시 \`dropSources\` 순회 → 확률 롤링 → \`Blueprints.Unlock\`

## 런타임 검증
\`\`\`
[Info :QuackForge] [Data.Weapons]    weapon registry ready — 10 entries.
[Info :QuackForge] [Data.Armors]     armor registry ready  — 5 entries.
[Info :QuackForge] [Data.Blueprints] blueprint registry ready — 10 entries, 0 unlocked.
[Info :QuackForge] 🦆 QuackForge is awake.
\`\`\`

## ⚠️ 미완료 — 워크벤치 통합
PRD §5.4.4 의 \`Workbench.GetAvailableRecipes\` Harmony 패치 경로는 실 게임 API 와 불일치. 실 게임 경로는 \`CraftingFormulaCollection\` SO + \`Item\` Prefab. AssetBundle 경로(#65) 확립 후 별도 이슈에서 \`Blueprints → CraftingManager.UnlockFormula\` 브릿지 구현.

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] Mac Duckov 런타임 10/10 도면 로드
- [x] \`consumeOnUse\` 플래그 역직렬화 (true/false 혼재)
- [ ] 실제 UnlockFormula 브릿지 — 후속 이슈 (#65 종속)

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)