### PR TITLE
release: v0.1.0-alpha.1 (Phase 1 closeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to QuackForge are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [SemVer](https://semver.org/).
+
+## [0.1.0-alpha.1] — 2026-04-22
+
+First tagged alpha. 데이터 파이프라인 + 인프라 + Mac/VM 양쪽 end-to-end 로드 검증 완료. 실제 게임 내 아이템 스폰/제작은 AssetBundle 경로(#65) 후속.
+
+### Added
+- **`QuackForge.Core`** — 공통 인프라 모듈.
+  - `QfLogger` 모듈 태그 로거 (BepInEx `ManualLogSource` 래퍼).
+  - `QfConfig` BepInEx `ConfigFile` 래퍼 + typed `Bind<T>`.
+  - `QfEventBus` 타입 기반 pub/sub (thread-safe).
+  - `QfSaveContext` in-memory 키-값 저장소 (Phase 2 에서 사이드카 JSON 로 확장 예정).
+  - `QfCore` 컴포지션 루트 싱글턴.
+- **`QuackForge.Data`** — 데이터 스키마 + 로더.
+  - `WeaponDefinition` + `WeaponRegistry` (embedded JSON, System.Text.Json).
+  - `ArmorDefinition` + `ArmorRegistry`.
+  - `BlueprintDefinition` + `BlueprintRegistry` (해금 상태 persist + 이벤트 발행).
+- **10종 무기 카탈로그**: AR 3 (ar_ranger / ar_duckstorm / ar_silencer_vx), SMG 2 (smg_vector_custom / smg_quickdraw), Shotgun 2 (sg_scattergun / sg_duckpunch), Sniper 1 (sr_quackshot), Pistol 2 (pistol_sidekick / pistol_thunderbill).
+- **5종 방어구 카탈로그**: chest_featherweight / chest_stealth_vest / chest_bulwark_plate / head_nightowl_helm / backpack_scavenger. `movementPenalty` 음수 허용으로 민첩 빌드 차별화.
+- **10종 블루프린트 카탈로그**: 각 무기 1:1 대응. Lv 1-22 구간, 보스 드랍 + 챌린지 guaranteed 조합, `consumeOnUse=true` 1개 포함.
+- **Mac 런처 스크립트**: `install-bepinex-mac.sh`, `run-duckov-mac.sh`, `deploy-mac.sh`. Apple Silicon arm64 → Rosetta x86_64 체인 + DYLD SIP 우회 + Steam DRM (`steam_appid.txt`) 자동 처리.
+- **Windows VM 런처 스크립트**: `install-bepinex-vm.ps1`, `run-duckov-vm.ps1`, `link-plugin-vm.ps1`. Parallels Shared Folders 기반 Mac↔VM 심볼릭 링크 파이프라인.
+- **문서**: `docs/official-mod-api-analysis.md`, `docs/reverse-engineering/weapons.md`, `docs/vm-setup-guide.md`, `docs/phase1-qa-report.md`.
+
+### Changed
+- **BepInEx**: PRD 초판 `5.4.21 unix_x64` → 런타임 `5.4.23.5 macos_universal`. Apple Silicon arm64 호환성 확보.
+- **Unity 타겟**: 2022.3.5f1 (PRD 초판) → 실 게임 2022.3.62f2 확인.
+
+### Infrastructure
+- 솔루션 3-프로젝트 구성: `QuackForge.Loader` (BepInEx 엔트리) + `QuackForge.Core` + `QuackForge.Data`. netstandard2.1 공통.
+- GitHub Issues 기반 Phase 0/1 전 작업 추적 완료 (#1-#18 closed).
+
+### Known Issues / Deferred
+- **AssetBundle 경로 미확립** (#65). 실 게임의 `CraftingFormulaCollection` (ScriptableObject) + Item Prefab 병합 경로는 Unity Editor 기반 모드 빌드가 필요. Part A (공식 Mod API) 실증 후속 sprint.
+- **게임 내 콘솔 스폰/워크벤치 제작 미검증**. 데이터 파이프라인 단계까지만 이번 alpha 에 포함.
+- 게임 종료 직후 `Index was out of range` 콘솔 에러 — `QuackForge unloaded` 이후 발생, 게임 내부 셧다운 이슈로 판단. 모니터링 대상.
+
+### Migration from v0.0.1 dev
+이 릴리즈 전에는 태그/리리즈 없음. 최초 태그.
+
+[0.1.0-alpha.1]: https://github.com/noel88/quackforge/releases/tag/v0.1.0-alpha.1

--- a/docs/phase1-qa-report.md
+++ b/docs/phase1-qa-report.md
@@ -1,0 +1,87 @@
+# Phase 1 QA Report — v0.1.0-alpha.1
+
+**작성일**: 2026-04-22
+**대상 빌드**: QuackForge 0.1.0-alpha.1
+**관련 이슈**: #16 (Mac 통합 테스트), #17 (VM QA)
+
+## 1. 환경
+
+| 플랫폼 | 버전 |
+|---|---|
+| macOS Host | Darwin 25.4.0 (arm64, Apple M1 Max) |
+| .NET SDK | 10.0.201 (netstandard2.1 타겟) |
+| BepInEx (Mac) | 5.4.23.5 macos_universal |
+| BepInEx (Win) | 5.4.23.5 win_x64 |
+| Duckov | v2.2.0 (Unity 2022.3.62f2) |
+| VM | Parallels Desktop + Windows 11 ARM |
+
+## 2. Mac 통합 테스트 (#16)
+
+### 검증 경로
+
+| 단계 | 결과 |
+|---|---|
+| `dotnet build -c Release` | ✅ 0 warn, 0 error |
+| `scripts/deploy-mac.sh` | ✅ 24개 DLL 배포 (QuackForge.* + 추이 deps) |
+| `scripts/run-duckov-mac.sh` | ✅ Rosetta x86_64 + DYLD 재주입 + BepInEx 로드 |
+| BepInEx 초기화 | ✅ `BepInEx 5.4.23.5 - Duckov` |
+| Unity 감지 | ✅ `Detected Unity version: v2022.3.62f2` |
+| 플러그인 로드 | ✅ `Loading [QuackForge 0.1.0]` (BepInPlugin attribute 는 numeric Version 만 허용, alpha suffix 는 git tag + CHANGELOG 에서만) |
+| QfCore 초기화 | ✅ `[Core] QfCore initialized.` |
+| 무기 레지스트리 | ✅ `weapon registry ready — 10 entries from 10 resources.` |
+| 방어구 레지스트리 | ✅ `armor registry ready — 5 entries from 5 resources.` |
+| 블루프린트 레지스트리 | ✅ `blueprint registry ready — 10 entries, 0 unlocked.` |
+| 메인 진입 | ✅ `🦆 QuackForge is awake. Forging begins.` |
+| 종료 | ✅ `QuackForge unloaded.` |
+
+### 미검증 (Part B 데이터-only 범위 밖)
+
+- ❌ 콘솔 스폰 → Item Prefab 필요, AssetBundle 경로 필수 (#65 후속)
+- ❌ 워크벤치 제작 → `CraftingFormulaCollection` SO 병합 필요 (#65)
+- ❌ VanillaAttachmentsExpanded 공존 (R1-5) → 모드 대상 AssetBundle 진입 후 재평가
+
+**결론**: **데이터 파이프라인은 완결**. 게임 내 실제 스폰/제작은 AssetBundle 경로 확립 후 #65 후속 이슈에서 검증.
+
+## 3. VM QA (#17)
+
+### 검증 경로
+
+| 단계 | 결과 |
+|---|---|
+| `install-bepinex-vm.ps1` | ✅ `BepInEx_win_x64_5.4.23.5` 자동 다운로드/설치 |
+| `link-plugin-vm.ps1` | ✅ `LinkType: SymbolicLink`, Target UNC Mac 경로 |
+| `run-duckov-vm.ps1` (Steam 경유) | ✅ 게임 실행 성공 |
+| BepInEx 초기화 | ✅ `BepInEx 5.4.23.5 - Duckov` + `System platform: Bits64, Windows` |
+| Unity 감지 | ✅ `Detected Unity version: v2022.3.62f2` |
+| Mac 빌드 DLL 즉시 반영 | ✅ Mac `dotnet build` → VM 덕코프 재시작만으로 업데이트 |
+| QfCore + 3 registries | ✅ Mac 와 동일 (10/5/10) |
+| FPS (x64 에뮬레이션) | ✅ **평균 70-80 FPS** (R0-1 기준 30 이상 넉넉히 통과) |
+
+### 프레임 드랍 리포트
+- 메인 메뉴·인벤토리·레이드 진입 구간 모두 60-80 FPS 구간 유지.
+- Parallels x64 에뮬이 Unity mono 와 BepInEx winhttp proxy DLL 을 무리 없이 소화.
+- 대규모 전투나 많은 엔티티 상황은 Phase 2 이후 추가 계측 필요.
+
+### 회귀 이슈
+- 게임 종료 시 `[Info : Console] Error: Index was out of range. startIndex` 발생 — `QuackForge unloaded` 이후라 우리 코드 아닌 게임 내부 셧다운 이슈. 모니터링 대상.
+
+## 4. Open Questions (Phase 2 이월)
+
+| ID | 질문 | 영향 |
+|---|---|---|
+| Q-PRD-UNITY | Unity 2022.3.5f1 → 2022.3.62f2 (PRD 초판 시점 대비 게임 업데이트) | 마이너, 호환 확인됨 |
+| Q-EXP-REUSE | `Duckov.EXPManager` 가 이미 존재 — 별도 궤도 vs 훅 확장 결정 | Phase 2 설계에 직접 영향 |
+| Q-ITEM-AB | AssetBundle 플랫폼 분리 빌드 필요 여부 (Mac arm64/x64, Win x64) | Phase 1 AssetBundle 후속 (#65) |
+| Q-MANIFEST | 공식 Mod 매니페스트 포맷 (info.ini vs mod.json vs 번들 메타) | #65 |
+| Q-FORMULA-MERGE | `CraftingFormulaCollection` 신규 formula 병합 공식 경로 | #65 |
+
+## 5. Phase 1 완료 기준 재평가
+
+PRD 의 Phase 1 Done:
+- [x] 무기 10 / 방어구 5 / 도면 10 JSON 정의 + embedded resource 로더 + 검증
+- [x] Core 인프라 (Logger / Config / EventBus / SaveContext) 실장
+- [x] Mac + VM 양쪽 환경에서 BepInEx + 플러그인 로드 end-to-end 검증
+- [x] 해금 상태 persist + 이벤트 발행 인프라 (Phase 2/4 대기)
+- [ ] **게임 내 실제 아이템 스폰/장착/제작** → **#65 (AssetBundle)** 로 이관
+
+**판정**: Phase 1 데이터·인프라 영역 **alpha 준비 완료**. 시각적 실증은 AssetBundle 확립 후 v0.1.0 (non-alpha) 혹은 v0.2 에 포함.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Build a distributable QuackForge ZIP for Nexus / manual install / beta testers.
+#
+# Produces: dist/quackforge-<version>.zip
+#
+# Layout inside the zip (what extracts into BepInEx/plugins/):
+#   QuackForge/
+#     QuackForge.Loader.dll
+#     QuackForge.Core.dll
+#     QuackForge.Data.dll
+#     <third-party deps not shipped by the game>
+#     README.txt  (install instructions)
+#
+# Usage:
+#   ./scripts/build-release.sh                 # build Release + package
+#   ./scripts/build-release.sh --skip-build    # package existing output
+#   ./scripts/build-release.sh --duckov <path> # override Mac Duckov dir used
+#                                              #   for dep-dedup check
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_OUTPUT="$REPO_ROOT/src/QuackForge.Loader/bin/Release"
+DIST_DIR="$REPO_ROOT/dist"
+DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
+
+SKIP_BUILD=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD=1 ;;
+    --duckov)     shift; DUCKOV_DIR="$1" ;;
+    -h|--help)    sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\033[0;36m[build-release]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[build-release]\033[0m %s\n' "$*" >&2; }
+
+# Pull version from Loader csproj — single source of truth.
+VERSION=$(grep -oE '<Version>[^<]+</Version>' \
+            "$REPO_ROOT/src/QuackForge.Loader/QuackForge.Loader.csproj" \
+          | head -1 | sed -E 's|</?Version>||g')
+if [[ -z "${VERSION:-}" ]]; then
+  err "failed to parse <Version> from QuackForge.Loader.csproj"
+  exit 1
+fi
+log "version: $VERSION"
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  log "dotnet build -c Release"
+  (cd "$REPO_ROOT" && dotnet build -c Release --nologo -v minimal)
+fi
+
+if [[ ! -f "$BUILD_OUTPUT/QuackForge.Loader.dll" ]]; then
+  err "build output missing: $BUILD_OUTPUT/QuackForge.Loader.dll"
+  exit 1
+fi
+
+# Stage contents that will extract as BepInEx/plugins/QuackForge/.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+PLUGIN_DIR="$STAGE/QuackForge"
+mkdir -p "$PLUGIN_DIR"
+
+DUCKOV_MANAGED="$DUCKOV_DIR/Duckov.app/Contents/Resources/Data/Managed"
+use_managed_filter=0
+if [[ -d "$DUCKOV_MANAGED" ]]; then
+  use_managed_filter=1
+  log "dedup check against: $DUCKOV_MANAGED"
+else
+  log "Duckov Managed dir not found — shipping all deps (safer default)"
+fi
+
+count=0
+for dll in "$BUILD_OUTPUT"/*.dll; do
+  [[ -f "$dll" ]] || continue
+  base=$(basename "$dll")
+  case "$base" in
+    QuackForge.*.dll)
+      cp "$dll" "$PLUGIN_DIR/"
+      count=$((count + 1))
+      ;;
+    *)
+      if [[ "$use_managed_filter" -eq 1 && -f "$DUCKOV_MANAGED/$base" ]]; then
+        continue
+      fi
+      cp "$dll" "$PLUGIN_DIR/"
+      count=$((count + 1))
+      ;;
+  esac
+done
+log "staged $count DLLs"
+
+# Install instructions inside the zip.
+cat > "$PLUGIN_DIR/README.txt" <<EOF
+QuackForge v$VERSION — Install Instructions
+
+Requirements:
+  1. Escape from Duckov (Steam)
+  2. BepInEx 5.4.23.5
+       - macOS (Apple Silicon): BepInEx_macos_universal_5.4.23.5.zip
+       - Windows x64:           BepInEx_win_x64_5.4.23.5.zip
+
+Installation:
+  1. Install BepInEx into the Duckov game directory (where Duckov.exe / Duckov.app lives).
+  2. Run Duckov once so BepInEx creates BepInEx/plugins/.
+  3. Extract this archive so the 'QuackForge' folder sits inside BepInEx/plugins/.
+     Expected path:
+       BepInEx/plugins/QuackForge/QuackForge.Loader.dll
+  4. Launch Duckov. Verify BepInEx/LogOutput.log contains:
+       [Info :QuackForge] 🦆 QuackForge is awake. Forging begins. (v$VERSION)
+
+macOS note:
+  Apple Silicon requires running Duckov under Rosetta (x86_64). Use the bundled
+  scripts/run-duckov-mac.sh from the repo, or see docs/vm-setup-guide.md.
+
+Source: https://github.com/noel88/quackforge
+EOF
+
+mkdir -p "$DIST_DIR"
+OUT="$DIST_DIR/quackforge-v$VERSION.zip"
+rm -f "$OUT"
+(cd "$STAGE" && zip -qr "$OUT" QuackForge)
+
+size=$(wc -c < "$OUT" | tr -d ' ')
+log "built → $OUT ($size bytes, $count DLLs + README.txt)"
+log "SHA256:"
+if command -v shasum >/dev/null 2>&1; then
+  shasum -a 256 "$OUT"
+else
+  sha256sum "$OUT"
+fi

--- a/src/QuackForge.Core/QuackForge.Core.csproj
+++ b/src/QuackForge.Core/QuackForge.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>QuackForge.Core</AssemblyName>
     <RootNamespace>QuackForge.Core</RootNamespace>
-    <Version>0.0.1</Version>
+    <Version>0.1.0-alpha.1</Version>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/QuackForge.Data/QuackForge.Data.csproj
+++ b/src/QuackForge.Data/QuackForge.Data.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>QuackForge.Data</AssemblyName>
     <RootNamespace>QuackForge.Data</RootNamespace>
-    <Version>0.0.1</Version>
+    <Version>0.1.0-alpha.1</Version>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -14,7 +14,9 @@ namespace QuackForge.Loader
     {
         public const string PluginGuid = "com.returntrue.quackforge";
         public const string PluginName = "QuackForge";
-        public const string PluginVersion = "0.0.1";
+        // BepInPlugin attribute 는 numeric System.Version 만 허용하므로 alpha suffix 는
+        // 생략. 실 릴리즈 태그는 v0.1.0-alpha.1 (CHANGELOG 및 git tag 참조).
+        public const string PluginVersion = "0.1.0";
 
         public static ManualLogSource Log { get; private set; } = null!;
         public static WeaponRegistry Weapons { get; private set; } = null!;

--- a/src/QuackForge.Loader/QuackForge.Loader.csproj
+++ b/src/QuackForge.Loader/QuackForge.Loader.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>QuackForge.Loader</AssemblyName>
     <RootNamespace>QuackForge.Loader</RootNamespace>
-    <Version>0.0.1</Version>
+    <Version>0.1.0-alpha.1</Version>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
## Summary
Phase 1 마무리 PR. QA 리포트 + CHANGELOG + 버전 bump.

## Changes
- \`CHANGELOG.md\` 신규 (Keep a Changelog, SemVer)
- \`docs/phase1-qa-report.md\` — #16 (Mac 통합) / #17 (VM QA) 결과, Open Questions 5개
- csproj \`Version\` 0.0.1 → **0.1.0-alpha.1** (3 프로젝트)
- Plugin.cs \`PluginVersion\` → **0.1.0** (BepInPlugin attribute 는 numeric System.Version 만 허용; alpha suffix 는 git tag + CHANGELOG 에서 표기)

## Phase 1 완료 범위
- Core 인프라 (#12): Logger / Config / EventBus / SaveContext
- Data 파이프라인: Weapons 10 (#13) / Armors 5 (#14) / Blueprints 10 (#15)
- Mac + Windows VM 양쪽 런처 스크립트 + end-to-end 로드 검증
- 역공학 문서 (#11) + 공식 Mod API 분석 (#10)

## 런타임 검증 (최종)
\`\`\`
[Info : BepInEx] Loading [QuackForge 0.1.0]
[Info :QuackForge] [Core] QfCore initialized.
[Info :QuackForge] [Data.Weapons] weapon registry ready — 10 entries from 10 resources.
[Info :QuackForge] [Data.Armors] armor registry ready — 5 entries from 5 resources.
[Info :QuackForge] [Data.Blueprints] blueprint registry ready — 10 entries, 0 unlocked.
[Info :QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.1.0)
[Message: BepInEx] Chainloader startup complete
\`\`\`

## 미완료 (Phase 1 범위 외)
AssetBundle 후속 이슈 #65 에서 처리:
- 실제 콘솔 스폰
- 워크벤치 제작 플로우
- VanillaAttachmentsExpanded 공존 (R1-5)

## 다음 단계
1. 이 PR 머지
2. \`git tag v0.1.0-alpha.1\` 생성 (develop 머지 후)
3. \`gh release create v0.1.0-alpha.1\` 으로 GitHub Release 게시
4. Phase 2 킥오프 — Q-EXP-REUSE 결정 (기존 \`Duckov.EXPManager\` 확장 vs 별도 QuackForge 레벨)

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] Mac 런타임: 3-registry 로드 확인
- [x] VM 런타임: FPS 70-80, BepInEx + 플러그인 로드 확인 (기존 검증, #4/#5/#9 close 시점)

Closes #16 #17 #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)