### PR TITLE
feat(#19 #20): QuackForge.Progression skeleton (Hybrid leveling)

### DIFF
--- a/QuackForge.sln
+++ b/QuackForge.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Core", "src\Quac
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Data", "src\QuackForge.Data\QuackForge.Data.csproj", "{C6056E9D-9406-4D95-9A28-F762D9AF893F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Progression", "src\QuackForge.Progression\QuackForge.Progression.csproj", "{5C652F35-C866-4F85-A694-23EB34E8730D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,18 @@ Global
 		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x64.Build.0 = Release|Any CPU
 		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x86.ActiveCfg = Release|Any CPU
 		{C6056E9D-9406-4D95-9A28-F762D9AF893F}.Release|x86.Build.0 = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x64.Build.0 = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -64,5 +78,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{02EE985A-1D28-4574-AC4B-460CD9A92254} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C6056E9D-9406-4D95-9A28-F762D9AF893F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{5C652F35-C866-4F85-A694-23EB34E8730D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -6,6 +6,7 @@ using QuackForge.Core;
 using QuackForge.Data.Armors;
 using QuackForge.Data.Blueprints;
 using QuackForge.Data.Weapons;
+using QuackForge.Progression;
 
 namespace QuackForge.Loader
 {
@@ -22,6 +23,7 @@ namespace QuackForge.Loader
         public static WeaponRegistry Weapons { get; private set; } = null!;
         public static ArmorRegistry Armors { get; private set; } = null!;
         public static BlueprintRegistry Blueprints { get; private set; } = null!;
+        public static QfProgression Progression { get; private set; } = null!;
 
         private Harmony _harmony = null!;
         private ConfigEntry<bool> _enableMod = null!;
@@ -55,7 +57,11 @@ namespace QuackForge.Loader
             Blueprints.LoadAll();
 
             _harmony = new Harmony(PluginGuid);
-            _harmony.PatchAll();
+            _harmony.PatchAll(typeof(Plugin).Assembly);
+            _harmony.PatchAll(typeof(QfProgression).Assembly);
+
+            // Harmony 패치가 Progression.Patches.* 를 등록한 뒤 Progression 초기화 (순서 의존 없음).
+            Progression = QfProgression.Initialize(pointsPerLevel: 1, autoAllocateVit: true);
 
             Log.LogInfo($"\ud83e\udd86 {PluginName} is awake. Forging begins. (v{PluginVersion})");
         }

--- a/src/QuackForge.Loader/QuackForge.Loader.csproj
+++ b/src/QuackForge.Loader/QuackForge.Loader.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\QuackForge.Core\QuackForge.Core.csproj" />
     <ProjectReference Include="..\QuackForge.Data\QuackForge.Data.csproj" />
+    <ProjectReference Include="..\QuackForge.Progression\QuackForge.Progression.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Progression/Debug/DebugCommands.cs
+++ b/src/QuackForge.Progression/Debug/DebugCommands.cs
@@ -1,0 +1,40 @@
+using Duckov;
+using QuackForge.Core.Logging;
+
+namespace QuackForge.Progression.Debug
+{
+    // Phase 2 개발/테스트용 디버그 커맨드. 게임 EXPManager 래퍼.
+    //
+    // BepInEx Configuration Manager (혹은 향후 UI) 에서 호출할 수 있도록 static.
+    // 실제 노출은 Plugin.Awake 에서 커맨드 시스템에 등록 (추후).
+    public static class DebugCommands
+    {
+        private static readonly IQfLog Log = QfLogger.For("Progression.Debug");
+
+        public static bool AddXp(int amount)
+        {
+            if (amount <= 0)
+            {
+                Log.Warn($"AddXp({amount}) rejected — must be positive");
+                return false;
+            }
+
+            if (EXPManager.Instance == null)
+            {
+                Log.Error("AddXp called but EXPManager.Instance is null (game not fully booted?)");
+                return false;
+            }
+
+            var before = EXPManager.EXP;
+            var ok = EXPManager.AddExp(amount);
+            if (!ok)
+            {
+                Log.Error("EXPManager.AddExp returned false");
+                return false;
+            }
+
+            Log.Info($"AddXp({amount}) — EXP {before} → {EXPManager.EXP}, Level={EXPManager.Level}");
+            return true;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/HealthMaxHealthPatch.cs
+++ b/src/QuackForge.Progression/Patches/HealthMaxHealthPatch.cs
@@ -1,0 +1,36 @@
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // Health.MaxHealth 의 getter 에 VIT × 10 을 가산.
+    //
+    // 대상 시그니처 (역공학 #11):
+    //   public float MaxHealth {
+    //       get { float num = !item ? defaultMaxHealth : item.GetStatValue(maxHealthHash); ... return num; }
+    //   }
+    //
+    // Phase 2 MVP 는 MainCharacterHealth 에만 적용하고자 하지만 성능상 단순히 Health 전체 포스트픽스 하되,
+    // IsMainCharacterHealth 체크로 가드. 적이나 NPC Health 에는 영향 주지 않음.
+    [HarmonyPatch(typeof(global::Health), nameof(global::Health.MaxHealth), MethodType.Getter)]
+    public static class HealthMaxHealthPatch
+    {
+        public const int HpPerVit = 10;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(global::Health __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacterHealth) return;
+
+            var vit = _stats.GetAllocated(StatType.VIT);
+            if (vit <= 0) return;
+
+            __result += vit * HpPerVit;
+        }
+    }
+}

--- a/src/QuackForge.Progression/QfProgression.cs
+++ b/src/QuackForge.Progression/QfProgression.cs
@@ -1,0 +1,52 @@
+using System;
+using QuackForge.Core;
+using QuackForge.Core.Logging;
+using QuackForge.Progression.Patches;
+using QuackForge.Progression.Stats;
+using QuackForge.Progression.Xp;
+
+namespace QuackForge.Progression
+{
+    public sealed class QfProgression
+    {
+        public static QfProgression? Instance { get; private set; }
+
+        public StatManager Stats { get; }
+        public XpSubscriber XpSubscriber { get; }
+
+        private readonly IQfLog _log = QfLogger.For("Progression");
+
+        private QfProgression(StatManager stats, XpSubscriber xp)
+        {
+            Stats = stats;
+            XpSubscriber = xp;
+        }
+
+        public static QfProgression Initialize(int pointsPerLevel = 1, bool autoAllocateVit = true)
+        {
+            if (Instance != null) throw new InvalidOperationException("QfProgression already initialized.");
+            var core = QfCore.Instance ?? throw new InvalidOperationException("QfCore not initialized — call QfCore.Initialize first.");
+
+            var stats = new StatManager(core.Events, core.Save);
+            stats.Restore();
+
+            var xp = new XpSubscriber(stats, pointsPerLevel);
+            xp.Subscribe();
+
+            HealthMaxHealthPatch.BindStats(stats);
+
+            if (autoAllocateVit)
+            {
+                // Phase 2 MVP: 이전 세션에서 분배 안 된 포인트가 있으면 전부 VIT 로 자동 투입.
+                stats.AutoAllocateVit();
+
+                // 이후 적립되는 포인트도 즉시 VIT 로 투입되도록 이벤트 구독.
+                core.Events.Subscribe<StatPointsGrantedEvent>(_ => stats.AutoAllocateVit());
+            }
+
+            Instance = new QfProgression(stats, xp);
+            Instance._log.Info($"QfProgression initialized (pointsPerLevel={pointsPerLevel}, autoAllocateVit={autoAllocateVit})");
+            return Instance;
+        }
+    }
+}

--- a/src/QuackForge.Progression/QuackForge.Progression.csproj
+++ b/src/QuackForge.Progression/QuackForge.Progression.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>QuackForge.Progression</AssemblyName>
+    <RootNamespace>QuackForge.Progression</RootNamespace>
+    <Version>0.1.0-alpha.1</Version>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <RestoreAdditionalProjectSources>https://nuget.bepinex.dev/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="HarmonyX" Version="2.10.2" />
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QuackForge.Core\QuackForge.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 게임 Managed 어셈블리 참조 (compile-time only, 덕코프 런타임에서 제공됨) -->
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(DuckovManagedPath)\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="TeamSoda.Duckov.Core">
+      <HintPath>$(DuckovManagedPath)\TeamSoda.Duckov.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="ItemStatsSystem">
+      <HintPath>$(DuckovManagedPath)\ItemStatsSystem.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- 기본값: Mac 스팀 경로. 다른 OS 에서는 환경변수 DUCKOV_MANAGED_PATH 로 덮어쓰기 가능. -->
+    <DuckovManagedPath Condition="'$(DUCKOV_MANAGED_PATH)' != ''">$(DUCKOV_MANAGED_PATH)</DuckovManagedPath>
+    <DuckovManagedPath Condition="'$(DuckovManagedPath)' == ''">$(HOME)/Library/Application Support/Steam/steamapps/common/Escape From Duckov/Duckov.app/Contents/Resources/Data/Managed</DuckovManagedPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/QuackForge.Progression/Stats/StatManager.cs
+++ b/src/QuackForge.Progression/Stats/StatManager.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using QuackForge.Core.Events;
+using QuackForge.Core.Logging;
+using QuackForge.Core.Save;
+
+namespace QuackForge.Progression.Stats
+{
+    // 스탯 포인트 적립 + 스탯별 투입량 관리.
+    // XP/레벨 계산은 게임 EXPManager 에 위임 (Hybrid 전략).
+    public sealed class StatManager
+    {
+        private const string SaveKey = "QuackForge.Progression.Stats";
+
+        private readonly Dictionary<StatType, int> _allocated = new();
+        private readonly IQfLog _log = QfLogger.For("Progression.Stats");
+        private readonly QfEventBus _bus;
+        private readonly QfSaveContext _save;
+
+        private int _unspent;
+
+        public StatManager(QfEventBus bus, QfSaveContext save)
+        {
+            _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+            _save = save ?? throw new ArgumentNullException(nameof(save));
+            foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                _allocated[s] = 0;
+        }
+
+        public int UnspentPoints => _unspent;
+
+        public int GetAllocated(StatType stat) => _allocated.TryGetValue(stat, out var v) ? v : 0;
+
+        public int TotalPoints
+        {
+            get
+            {
+                int sum = _unspent;
+                foreach (var v in _allocated.Values) sum += v;
+                return sum;
+            }
+        }
+
+        public void GrantPoints(int amount, string source)
+        {
+            if (amount <= 0) return;
+            _unspent += amount;
+            _log.Info($"+{amount} stat points (source={source}, unspent={_unspent})");
+            _bus.Publish(new StatPointsGrantedEvent(amount, _unspent, source));
+            Persist();
+        }
+
+        public bool Allocate(StatType stat, int amount)
+        {
+            if (amount <= 0) return false;
+            if (_unspent < amount)
+            {
+                _log.Warn($"Allocate({stat}, {amount}) rejected — unspent={_unspent}");
+                return false;
+            }
+            _unspent -= amount;
+            _allocated[stat] = GetAllocated(stat) + amount;
+            _log.Info($"allocated +{amount} to {stat} (now={_allocated[stat]}, unspent={_unspent})");
+            _bus.Publish(new StatAllocatedEvent(stat, amount, _allocated[stat]));
+            Persist();
+            return true;
+        }
+
+        // Phase 2 MVP: 누적 포인트 전부 VIT 로 자동 투입.
+        public void AutoAllocateVit()
+        {
+            if (_unspent <= 0) return;
+            var amount = _unspent;
+            Allocate(StatType.VIT, amount);
+        }
+
+        public void Reset()
+        {
+            _unspent = 0;
+            foreach (StatType s in Enum.GetValues(typeof(StatType))) _allocated[s] = 0;
+            Persist();
+        }
+
+        public void Restore()
+        {
+            if (!_save.TryGet<StatSnapshot>(SaveKey, out var snap)) return;
+            _unspent = snap.Unspent;
+            foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                _allocated[s] = snap.Allocated != null && snap.Allocated.TryGetValue(s, out var v) ? v : 0;
+            _log.Info($"restored — unspent={_unspent}, VIT={_allocated[StatType.VIT]}");
+        }
+
+        private void Persist()
+        {
+            _save.Set(SaveKey, new StatSnapshot
+            {
+                Unspent = _unspent,
+                Allocated = new Dictionary<StatType, int>(_allocated),
+            });
+        }
+
+        // Save 레이어에 들어갈 직렬화용 스냅샷.
+        public sealed class StatSnapshot
+        {
+            public int Unspent { get; set; }
+            public Dictionary<StatType, int> Allocated { get; set; } = new();
+        }
+    }
+
+    public readonly struct StatPointsGrantedEvent
+    {
+        public int Amount { get; }
+        public int UnspentAfter { get; }
+        public string Source { get; }
+        public StatPointsGrantedEvent(int amount, int unspentAfter, string source)
+        {
+            Amount = amount;
+            UnspentAfter = unspentAfter;
+            Source = source;
+        }
+    }
+
+    public readonly struct StatAllocatedEvent
+    {
+        public StatType Stat { get; }
+        public int Amount { get; }
+        public int AllocatedAfter { get; }
+        public StatAllocatedEvent(StatType stat, int amount, int allocatedAfter)
+        {
+            Stat = stat;
+            Amount = amount;
+            AllocatedAfter = allocatedAfter;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Stats/StatType.cs
+++ b/src/QuackForge.Progression/Stats/StatType.cs
@@ -1,0 +1,21 @@
+namespace QuackForge.Progression.Stats
+{
+    // PRD §6.3 5-스탯 시스템. Phase 2 MVP 는 VIT 만 실제 효과 반영, 나머지는 enum 선반영.
+    public enum StatType
+    {
+        // Vitality — MaxHP 증가
+        VIT = 0,
+
+        // Strength — 근접 데미지, 권총 데미지 (Phase 3)
+        STR = 1,
+
+        // Agility — 이동 속도, 민첩성 (Phase 3)
+        AGI = 2,
+
+        // Precision — 명중률, 헤드샷 배수 (Phase 3)
+        PRE = 3,
+
+        // Survival — 스태미나, 방어 계수 (Phase 3)
+        SUR = 4,
+    }
+}

--- a/src/QuackForge.Progression/Xp/XpSubscriber.cs
+++ b/src/QuackForge.Progression/Xp/XpSubscriber.cs
@@ -1,0 +1,48 @@
+using System;
+using Duckov;
+using QuackForge.Core.Logging;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Xp
+{
+    // 게임의 EXPManager.onLevelChanged(int prev, int next) 구독 → 스탯 포인트 적립.
+    // Hybrid 전략: XP/레벨 계산은 게임에 위임, 우리는 레벨업 이벤트만 사용.
+    public sealed class XpSubscriber : IDisposable
+    {
+        private readonly StatManager _stats;
+        private readonly IQfLog _log = QfLogger.For("Progression.Xp");
+        private readonly int _pointsPerLevel;
+        private bool _subscribed;
+
+        public XpSubscriber(StatManager stats, int pointsPerLevel = 1)
+        {
+            _stats = stats ?? throw new ArgumentNullException(nameof(stats));
+            _pointsPerLevel = Math.Max(1, pointsPerLevel);
+        }
+
+        public void Subscribe()
+        {
+            if (_subscribed) return;
+            EXPManager.onLevelChanged += OnLevelChanged;
+            _subscribed = true;
+            _log.Info($"subscribed to EXPManager.onLevelChanged (points/level = {_pointsPerLevel})");
+        }
+
+        public void Unsubscribe()
+        {
+            if (!_subscribed) return;
+            EXPManager.onLevelChanged -= OnLevelChanged;
+            _subscribed = false;
+        }
+
+        public void Dispose() => Unsubscribe();
+
+        private void OnLevelChanged(int prev, int next)
+        {
+            if (next <= prev) return; // 하향 조정은 포인트 반환 안 함 (Phase 2 범위 밖)
+            var gained = (next - prev) * _pointsPerLevel;
+            _log.Info($"level {prev} → {next} — granting {gained} stat points");
+            _stats.GrantPoints(gained, $"level {prev}→{next}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 Progression 모듈 스켈레톤. PRD §6.0 Hybrid 전략 반영 — XP/레벨 계산은 게임 \`Duckov.EXPManager\` 에 위임, 우리는 \`onLevelChanged\` 구독 후 스탯 포인트 적립·분배·적용.

## Architecture

\`\`\`
EXPManager.onLevelChanged ──▶ XpSubscriber ──▶ StatManager.GrantPoints
                                                    │
                                                    ▼
                                              (auto VIT 투입)
                                                    │
                                                    ▼
                                    Health.MaxHealth Harmony Postfix
                                       (VIT × 10 가산)
\`\`\`

## Components

| 파일 | 역할 |
|---|---|
| \`Stats/StatType.cs\` | VIT/STR/AGI/PRE/SUR enum (MVP 는 VIT 만 실효) |
| \`Stats/StatManager.cs\` | 포인트 적립/분배 + persist + 이벤트 발행 |
| \`Xp/XpSubscriber.cs\` | \`EXPManager.onLevelChanged\` 구독 |
| \`Patches/HealthMaxHealthPatch.cs\` | Harmony Postfix: MainCharacter 한정 MaxHP 가산 |
| \`Debug/DebugCommands.cs\` | \`AddXp(int)\` — 게임 EXPManager.AddExp 래핑 |
| \`QfProgression.cs\` | 컴포지션 루트 싱글턴 |

## 런타임 검증
\`\`\`
[Info :QuackForge] [Core] QfCore initialized.
[Info :QuackForge] [Data.Weapons]    weapon registry ready — 10 entries.
[Info :QuackForge] [Data.Armors]     armor registry ready  — 5 entries.
[Info :QuackForge] [Data.Blueprints] blueprint registry ready — 10 entries, 0 unlocked.
[Info :QuackForge] [Progression.Xp] subscribed to EXPManager.onLevelChanged (points/level = 1)
[Info :QuackForge] [Progression] QfProgression initialized (pointsPerLevel=1, autoAllocateVit=True)
[Info :QuackForge] 🦆 QuackForge is awake. Forging begins. (v0.1.0)
\`\`\`

## 게임 DLL 참조 전략
csproj 에 \`DuckovManagedPath\` 프로퍼티 + 환경변수 \`DUCKOV_MANAGED_PATH\` 오버라이드. 기본값은 Mac Steam 경로. Private=false 로 출력물에 복사되지 않음 (런타임에 게임이 제공).

## 현재 Phase 2 이슈 진행도
- [x] T2.1 (#19): Health/EXPManager RE는 #11 문서에 포함, 이 PR 이 코드로 활용
- [x] T2.2 (#20): Progression 모듈 뼈대
- [x] T2.3: StatManager
- [x] T2.6: HP Harmony 패치 스켈레톤 (실제 레벨업 후 HP 증가는 인게임 QA 필요)
- [ ] T2.5 (quackforge.json 사이드카 파일 IO) — 후속
- [ ] T2.7 (토스트 UI), T2.8 (콘솔 명령 노출) — 후속
- [ ] T2.4 (XpCollector) — **삭제** (Hybrid 결정, PRD §6.0)
- [ ] T2.9, T2.10 — Phase 2 종료 시

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] 런타임: Progression 초기화 로그 확인
- [x] Harmony PatchAll 통과 (런타임 에러 없음)
- [ ] 인게임 레벨업 후 MaxHP +10 확인 (사용자 테스트 필요 — \`DebugCommands.AddXp\` 노출 후)

Refs #19 #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)