### PR TITLE
feat: Phase 2 sidecar IO + debug overlay + AddXp keybind (#23 #25 #26)

### DIFF
--- a/src/QuackForge.Core/QfCore.cs
+++ b/src/QuackForge.Core/QfCore.cs
@@ -23,15 +23,18 @@ namespace QuackForge.Core
             Save = save;
         }
 
-        public static QfCore Initialize(ManualLogSource rootLog, ConfigFile configFile)
+        public static QfCore Initialize(ManualLogSource rootLog, ConfigFile configFile, string? saveFilePath = null)
         {
             if (Instance != null) throw new InvalidOperationException("QfCore already initialized.");
             if (rootLog == null) throw new ArgumentNullException(nameof(rootLog));
             if (configFile == null) throw new ArgumentNullException(nameof(configFile));
 
             QfLogger.Init(rootLog);
-            Instance = new QfCore(new QfConfig(configFile), new QfEventBus(), new QfSaveContext());
-            QfLogger.For("Core").Info("QfCore initialized.");
+            Instance = new QfCore(new QfConfig(configFile), new QfEventBus(), new QfSaveContext(saveFilePath));
+            var log = QfLogger.For("Core");
+            log.Info(saveFilePath == null
+                ? "QfCore initialized (in-memory save)"
+                : $"QfCore initialized (save → {saveFilePath})");
             return Instance;
         }
     }

--- a/src/QuackForge.Core/QuackForge.Core.csproj
+++ b/src/QuackForge.Core/QuackForge.Core.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/QuackForge.Core/Save/QfSaveContext.cs
+++ b/src/QuackForge.Core/Save/QfSaveContext.cs
@@ -1,19 +1,59 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using QuackForge.Core.Logging;
 
 namespace QuackForge.Core.Save
 {
-    // Phase 1 stub: in-memory store. Phase 2 (T2.5) 에서 quackforge.json 사이드카로 확장.
-    // 게임의 SavesSystem 직접 사용이 아닌 사이드카 전략 (PRD 결정 2-1).
+    // 모드 사이드카 세이브. 게임의 SavesSystem 과 독립된 quackforge.json 단일 파일.
+    //
+    // 설계 원칙 (PRD 결정 2-1):
+    //   - 게임 세이브와 분리 → 게임 업데이트로 세이브 포맷 변경돼도 안전
+    //   - 사용자가 모드 제거해도 게임 세이브 그대로
+    //   - JSON text 포맷 → 사용자가 필요 시 수동 편집/복구 가능
+    //
+    // 파일 위치:
+    //   기본: ~/Library/Application Support/Steam/steamapps/common/Escape From Duckov/BepInEx/quackforge.json (Mac)
+    //   구성: QfSaveContext(Path) 생성자로 오버라이드 가능
+    //
+    // 값은 타입 이름 + JSON 문자열로 저장. 재구동 시 같은 타입으로 역직렬화.
+    // 복잡한 객체 (Dictionary<Enum, int> 등) 도 동작하도록 JsonSerializer 에 위임.
     public sealed class QfSaveContext
     {
-        private readonly Dictionary<string, object?> _store = new Dictionary<string, object?>(StringComparer.Ordinal);
-        private readonly object _lock = new object();
+        private static readonly JsonSerializerOptions JsonOpts = new()
+        {
+            WriteIndented = true,
+            IncludeFields = true,
+        };
+
+        private readonly string? _filePath;
+        private readonly Dictionary<string, Entry> _store = new(StringComparer.Ordinal);
+        private readonly object _lock = new();
+        private readonly IQfLog _log = QfLogger.For("Core.Save");
+
+        private bool _dirty;
+
+        public QfSaveContext()
+            : this(filePath: null) { }
+
+        public QfSaveContext(string? filePath)
+        {
+            _filePath = filePath;
+            if (!string.IsNullOrEmpty(_filePath)) Load();
+        }
+
+        public string? FilePath => _filePath;
 
         public void Set<T>(string key, T value)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
-            lock (_lock) _store[key] = value;
+            var json = JsonSerializer.Serialize(value, typeof(T), JsonOpts);
+            lock (_lock)
+            {
+                _store[key] = new Entry { TypeName = SimpleTypeName(typeof(T)), Json = json };
+                _dirty = true;
+            }
         }
 
         public bool TryGet<T>(string key, out T value)
@@ -21,10 +61,21 @@ namespace QuackForge.Core.Save
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
             lock (_lock)
             {
-                if (_store.TryGetValue(key, out var raw) && raw is T typed)
+                if (_store.TryGetValue(key, out var entry) && entry != null)
                 {
-                    value = typed;
-                    return true;
+                    try
+                    {
+                        var parsed = JsonSerializer.Deserialize<T>(entry.Json, JsonOpts);
+                        if (parsed != null)
+                        {
+                            value = parsed;
+                            return true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error($"TryGet<{typeof(T).Name}>('{key}') deserialize failed", ex);
+                    }
                 }
             }
             value = default!;
@@ -34,12 +85,96 @@ namespace QuackForge.Core.Save
         public bool Remove(string key)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
-            lock (_lock) return _store.Remove(key);
+            lock (_lock)
+            {
+                if (_store.Remove(key))
+                {
+                    _dirty = true;
+                    return true;
+                }
+                return false;
+            }
         }
 
         public void Clear()
         {
-            lock (_lock) _store.Clear();
+            lock (_lock)
+            {
+                _store.Clear();
+                _dirty = true;
+            }
+        }
+
+        // 명시적으로 호출. Plugin 쪽에서 주기적으로 or OnDestroy 에서 트리거 예정.
+        public bool FlushIfDirty()
+        {
+            if (string.IsNullOrEmpty(_filePath)) return false;
+            Dictionary<string, Entry> snapshot;
+            lock (_lock)
+            {
+                if (!_dirty) return false;
+                snapshot = new Dictionary<string, Entry>(_store, StringComparer.Ordinal);
+                _dirty = false;
+            }
+
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+
+                var tmp = _filePath + ".tmp";
+                var payload = JsonSerializer.Serialize(new FileFormat { Version = 1, Entries = snapshot }, JsonOpts);
+                File.WriteAllText(tmp, payload);
+                if (File.Exists(_filePath)) File.Delete(_filePath);
+                File.Move(tmp, _filePath);
+                _log.Debug($"flushed {snapshot.Count} entries → {_filePath}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _log.Error($"flush failed: {_filePath}", ex);
+                // 다음 주기에 재시도
+                lock (_lock) _dirty = true;
+                return false;
+            }
+        }
+
+        private void Load()
+        {
+            if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath)) return;
+            try
+            {
+                var payload = File.ReadAllText(_filePath);
+                var parsed = JsonSerializer.Deserialize<FileFormat>(payload, JsonOpts);
+                if (parsed?.Entries == null) return;
+
+                lock (_lock)
+                {
+                    _store.Clear();
+                    foreach (var kv in parsed.Entries) _store[kv.Key] = kv.Value;
+                    _dirty = false;
+                }
+                _log.Info($"loaded {parsed.Entries.Count} entries from {_filePath}");
+            }
+            catch (Exception ex)
+            {
+                _log.Error($"load failed: {_filePath} — starting empty", ex);
+            }
+        }
+
+        private static string SimpleTypeName(Type t) => t.FullName ?? t.Name;
+
+        // On-disk 포맷 (버전 1). 향후 스키마 마이그레이션 지점.
+        private sealed class FileFormat
+        {
+            public int Version { get; set; } = 1;
+            public Dictionary<string, Entry> Entries { get; set; } = new();
+        }
+
+        private sealed class Entry
+        {
+            public string TypeName { get; set; } = "";
+            public string Json { get; set; } = "";
         }
     }
 }

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
@@ -6,7 +7,10 @@ using QuackForge.Core;
 using QuackForge.Data.Armors;
 using QuackForge.Data.Blueprints;
 using QuackForge.Data.Weapons;
+using QuackForge.Loader.UI;
 using QuackForge.Progression;
+using QuackForge.Progression.Debug;
+using UnityEngine;
 
 namespace QuackForge.Loader
 {
@@ -27,6 +31,12 @@ namespace QuackForge.Loader
 
         private Harmony _harmony = null!;
         private ConfigEntry<bool> _enableMod = null!;
+        private ConfigEntry<bool> _debugOverlayEnabled = null!;
+        private ConfigEntry<KeyboardShortcut> _debugAddXpKey = null!;
+        private ConfigEntry<int> _debugAddXpAmount = null!;
+        private ConfigEntry<float> _saveFlushIntervalSec = null!;
+
+        private float _nextFlushAt;
 
         private void Awake()
         {
@@ -44,7 +54,32 @@ namespace QuackForge.Loader
                 return;
             }
 
-            QfCore.Initialize(Log, Config);
+            _debugOverlayEnabled = Config.Bind(
+                "Debug",
+                "OverlayEnabled",
+                true,
+                "Show the IMGUI overlay (level-up toast + stat summary). Disable for release-like playtest.");
+
+            _debugAddXpKey = Config.Bind(
+                "Debug",
+                "AddXpKey",
+                new KeyboardShortcut(KeyCode.F9),
+                "Press to grant debug XP to the player (goes through game's EXPManager.AddExp).");
+
+            _debugAddXpAmount = Config.Bind(
+                "Debug",
+                "AddXpAmount",
+                1000,
+                "XP amount to grant per AddXp hotkey press.");
+
+            _saveFlushIntervalSec = Config.Bind(
+                "General",
+                "SaveFlushIntervalSec",
+                15f,
+                "Interval between sidecar quackforge.json flushes (seconds).");
+
+            var savePath = ResolveSaveFilePath();
+            QfCore.Initialize(Log, Config, savePath);
 
             Weapons = new WeaponRegistry();
             Weapons.LoadAll();
@@ -63,13 +98,44 @@ namespace QuackForge.Loader
             // Harmony 패치가 Progression.Patches.* 를 등록한 뒤 Progression 초기화 (순서 의존 없음).
             Progression = QfProgression.Initialize(pointsPerLevel: 1, autoAllocateVit: true);
 
+            if (_debugOverlayEnabled.Value) DebugOverlay.Attach(this, Progression, core.Events);
+
+            _nextFlushAt = Time.realtimeSinceStartup + _saveFlushIntervalSec.Value;
+
             Log.LogInfo($"\ud83e\udd86 {PluginName} is awake. Forging begins. (v{PluginVersion})");
+        }
+
+        private void Update()
+        {
+            if (_enableMod == null || !_enableMod.Value) return;
+
+            // Debug: AddXp 키바인드
+            if (_debugAddXpKey != null && _debugAddXpKey.Value.IsDown())
+            {
+                DebugCommands.AddXp(_debugAddXpAmount.Value);
+            }
+
+            // 주기적 사이드카 flush
+            if (Time.realtimeSinceStartup >= _nextFlushAt)
+            {
+                QfCore.Instance?.Save.FlushIfDirty();
+                _nextFlushAt = Time.realtimeSinceStartup + _saveFlushIntervalSec.Value;
+            }
         }
 
         private void OnDestroy()
         {
             _harmony?.UnpatchSelf();
+            QfCore.Instance?.Save.FlushIfDirty();
             Log?.LogInfo($"{PluginName} unloaded.");
+        }
+
+        private static string ResolveSaveFilePath()
+        {
+            // BepInEx.Paths.ConfigPath 는 BepInEx/config/. 같은 계층에 quackforge.json 둬서
+            // 모드 사이드카임을 드러냄. 게임 자체 세이브와 분리 (PRD 결정 2-1).
+            var bepinexRoot = Path.GetDirectoryName(Paths.ConfigPath) ?? Paths.BepInExRootPath;
+            return Path.Combine(bepinexRoot, "quackforge.json");
         }
     }
 }

--- a/src/QuackForge.Loader/UI/DebugOverlay.cs
+++ b/src/QuackForge.Loader/UI/DebugOverlay.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using QuackForge.Core.Events;
+using QuackForge.Core.Logging;
+using QuackForge.Progression;
+using QuackForge.Progression.Stats;
+using UnityEngine;
+
+namespace QuackForge.Loader.UI
+{
+    // IMGUI 기반 개발용 오버레이.
+    // - 우상단 스탯 요약 (현재 VIT / unspent points)
+    // - 레벨업 / 포인트 적립 이벤트 시 토스트 (3초 노출)
+    //
+    // Phase 3 의 진짜 UI 가 준비되면 ConfigEntry "OverlayEnabled" = false 로 비활성화.
+    // Unity GameObject 로 싱글턴 MonoBehaviour 부착.
+    public sealed class DebugOverlay : MonoBehaviour
+    {
+        private const float ToastDurationSec = 3.0f;
+        private const int MaxToasts = 4;
+
+        private static DebugOverlay? _instance;
+
+        private QfProgression? _progression;
+        private readonly List<Toast> _toasts = new();
+        private readonly IQfLog _log = QfLogger.For("UI.Overlay");
+
+        private GUIStyle? _headerStyle;
+        private GUIStyle? _lineStyle;
+        private GUIStyle? _toastStyle;
+
+        public static void Attach(MonoBehaviour host, QfProgression progression, QfEventBus bus)
+        {
+            if (_instance != null) return;
+
+            var go = new GameObject("QuackForgeDebugOverlay");
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<DebugOverlay>();
+            _instance._progression = progression;
+
+            bus.Subscribe<StatPointsGrantedEvent>(_instance.OnPointsGranted);
+            bus.Subscribe<StatAllocatedEvent>(_instance.OnStatAllocated);
+            _instance._log.Info("DebugOverlay attached");
+        }
+
+        private void OnPointsGranted(StatPointsGrantedEvent evt)
+        {
+            Push($"+{evt.Amount} pts ({evt.Source})");
+        }
+
+        private void OnStatAllocated(StatAllocatedEvent evt)
+        {
+            Push($"{evt.Stat} +{evt.Amount} → {evt.AllocatedAfter}");
+        }
+
+        private void Push(string message)
+        {
+            _toasts.Add(new Toast { Message = message, ExpireAt = Time.realtimeSinceStartup + ToastDurationSec });
+            if (_toasts.Count > MaxToasts) _toasts.RemoveAt(0);
+        }
+
+        private void OnGUI()
+        {
+            _headerStyle ??= BuildStyle(fontSize: 14, color: new Color(1f, 0.85f, 0.35f, 1f), bold: true);
+            _lineStyle   ??= BuildStyle(fontSize: 13, color: new Color(0.9f, 0.9f, 0.9f, 0.95f), bold: false);
+            _toastStyle  ??= BuildStyle(fontSize: 15, color: new Color(0.6f, 1f, 0.6f, 1f), bold: true);
+
+            DrawStatSummary();
+            DrawToasts();
+        }
+
+        private void DrawStatSummary()
+        {
+            if (_progression == null) return;
+            var stats = _progression.Stats;
+
+            var w = 260f;
+            var h = 92f;
+            var x = Screen.width - w - 16f;
+            var y = 16f;
+
+            GUI.Box(new Rect(x, y, w, h), GUIContent.none);
+            GUILayout.BeginArea(new Rect(x + 8, y + 6, w - 16, h - 12));
+            GUILayout.Label("QuackForge", _headerStyle);
+            GUILayout.Label($"Unspent: {stats.UnspentPoints}", _lineStyle);
+            GUILayout.Label($"VIT: {stats.GetAllocated(StatType.VIT)}  STR: {stats.GetAllocated(StatType.STR)}  AGI: {stats.GetAllocated(StatType.AGI)}", _lineStyle);
+            GUILayout.Label($"PRE: {stats.GetAllocated(StatType.PRE)}  SUR: {stats.GetAllocated(StatType.SUR)}", _lineStyle);
+            GUILayout.EndArea();
+        }
+
+        private void DrawToasts()
+        {
+            var now = Time.realtimeSinceStartup;
+            _toasts.RemoveAll(t => t.ExpireAt <= now);
+            if (_toasts.Count == 0) return;
+
+            var w = 260f;
+            var h = 24f;
+            var x = Screen.width - w - 16f;
+            var y = 120f;
+
+            for (int i = 0; i < _toasts.Count; i++)
+            {
+                var toast = _toasts[i];
+                var remaining = toast.ExpireAt - now;
+                var alpha = Mathf.Clamp01(remaining / ToastDurationSec);
+                var prev = GUI.color;
+                GUI.color = new Color(1f, 1f, 1f, alpha);
+                GUI.Box(new Rect(x, y + i * (h + 4), w, h), GUIContent.none);
+                GUI.Label(new Rect(x + 8, y + i * (h + 4) + 4, w - 16, h), toast.Message, _toastStyle);
+                GUI.color = prev;
+            }
+        }
+
+        private static GUIStyle BuildStyle(int fontSize, Color color, bool bold)
+        {
+            return new GUIStyle
+            {
+                fontSize = fontSize,
+                fontStyle = bold ? FontStyle.Bold : FontStyle.Normal,
+                normal = new GUIStyleState { textColor = color },
+            };
+        }
+
+        private struct Toast
+        {
+            public string Message;
+            public float ExpireAt;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 남은 T2.5 / T2.7 / T2.8 묶음.

## 변경

### T2.5 — \`quackforge.json\` 사이드카 IO
- \`QfSaveContext\` 가 이제 디스크 지속.
- \`Set<T>(key, value)\` → 타입+JSON 직렬화해서 캐시 + dirty 플래그
- \`FlushIfDirty()\` → atomic \`tmp → target\` 이름 변경으로 쓰기
- 생성자에서 기존 파일 역직렬화
- 파일 경로: \`BepInEx/quackforge.json\` (게임 세이브와 분리, PRD 결정 2-1)

### T2.7 — \`DebugOverlay\` (IMGUI 레벨업 알림)
- 우상단 박스: VIT/STR/AGI/PRE/SUR + unspent points
- \`StatPointsGrantedEvent\` / \`StatAllocatedEvent\` 구독 → 3초 페이드 토스트
- \`Config.Debug.OverlayEnabled\` 로 끌 수 있음

### T2.8 — \`AddXp\` 디버그 키바인드
- \`Config.Debug.AddXpKey\` (default F9), \`AddXpAmount\` (default 1000)
- 키 눌림 감지 → \`DebugCommands.AddXp\` → 게임 \`EXPManager.AddExp\` 래핑
- 플레이어 레벨업 → 우리 XpSubscriber → VIT 자동 투입 → Health 패치 HP +10 →
  오버레이 토스트 → quackforge.json flush 의 전체 체인 테스트 동력

### 설정 엔트리 (BepInEx config)
- \`General.SaveFlushIntervalSec\` (default 15s)
- \`Debug.OverlayEnabled\` (default true)
- \`Debug.AddXpKey\` (default F9)
- \`Debug.AddXpAmount\` (default 1000)

## 런타임 검증
\`\`\`
[Core] QfCore initialized (save → /…/BepInEx/quackforge.json)
[Progression] QfProgression initialized (pointsPerLevel=1, autoAllocateVit=True)
[UI.Overlay] DebugOverlay attached
\`\`\`

## 남은 인게임 QA (F9 반복으로 확인 필요)
- [ ] F9 한번 누를 때마다 EXPManager.EXP 증가
- [ ] 특정 XP 도달 시 \`onLevelChanged\` 발화 → "+1 pts" 토스트
- [ ] 자동 VIT 투입 → "VIT +1 → 1" 토스트
- [ ] 플레이어 HP 바가 +10 증가한 표시
- [ ] 게임 종료 + 재시작 시 \`quackforge.json\` 에서 VIT 복원 (로그 "restored — VIT=N")

Refs #23 #25 #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)