### PR TITLE
feat(#65): minimal official-mod-path test (quackforge_test)

### DIFF
--- a/QuackForge.sln
+++ b/QuackForge.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Data", "src\Quac
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.Progression", "src\QuackForge.Progression\QuackForge.Progression.csproj", "{5C652F35-C866-4F85-A694-23EB34E8730D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuackForge.TestMod", "src\QuackForge.TestMod\QuackForge.TestMod.csproj", "{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,18 @@ Global
 		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x64.Build.0 = Release|Any CPU
 		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x86.ActiveCfg = Release|Any CPU
 		{5C652F35-C866-4F85-A694-23EB34E8730D}.Release|x86.Build.0 = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|x64.Build.0 = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|x64.ActiveCfg = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|x64.Build.0 = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,5 +93,6 @@ Global
 		{02EE985A-1D28-4574-AC4B-460CD9A92254} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C6056E9D-9406-4D95-9A28-F762D9AF893F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5C652F35-C866-4F85-A694-23EB34E8730D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{9EA2BB88-DF54-4708-BBB5-FE3A40B93D4F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/scripts/deploy-testmod-mac.sh
+++ b/scripts/deploy-testmod-mac.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Deploy the minimal official-mod-path test (#65) to Duckov Mods folder on Mac.
+#
+# Produces:
+#   <Duckov.app>/Contents/Resources/Data/Mods/quackforge_test/
+#     ├── info.ini
+#     └── quackforge_test.dll
+#
+# 사용자는 이후:
+#   1. 덕코프 실행 (Steam 또는 run-duckov-mac.sh)
+#   2. 메인 메뉴 → Mods → 약관 수락 (AllowActivatingMod = true)
+#   3. quackforge_test 토글 ON
+#   4. BepInEx/LogOutput.log (또는 Unity Player.log) 확인
+#      → "[QuackForge.TestMod] OnAfterSetup — hello from official Duckov mod path."
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJ_DIR="$REPO_ROOT/src/QuackForge.TestMod"
+BUILD_OUTPUT="$PROJ_DIR/bin/Release"
+
+DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
+MODS_DIR="$DUCKOV_DIR/Duckov.app/Contents/Resources/Data/Mods"
+TARGET_DIR="$MODS_DIR/quackforge_test"
+
+SKIP_BUILD=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD=1 ;;
+    -h|--help)    sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\033[0;36m[deploy-testmod]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[deploy-testmod]\033[0m %s\n' "$*" >&2; }
+
+if [[ ! -d "$DUCKOV_DIR" ]]; then
+  err "Duckov not found: $DUCKOV_DIR"
+  exit 1
+fi
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  log "dotnet build (QuackForge.TestMod, Release)"
+  (cd "$PROJ_DIR" && dotnet build -c Release --nologo -v minimal)
+fi
+
+DLL="$BUILD_OUTPUT/quackforge_test.dll"
+if [[ ! -f "$DLL" ]]; then
+  err "build output missing: $DLL"
+  exit 1
+fi
+
+log "Mods dir: $MODS_DIR"
+mkdir -p "$TARGET_DIR"
+cp "$DLL" "$TARGET_DIR/"
+cp "$PROJ_DIR/info.ini" "$TARGET_DIR/"
+
+log "deployed:"
+ls -la "$TARGET_DIR" | sed 's|^|  |'
+
+cat <<'NEXT'
+
+Next steps (in-game):
+  1. Launch Duckov (scripts/run-duckov-mac.sh)
+  2. Main menu → Mods
+  3. Accept the mod agreement if you haven't (AllowActivatingMod = true)
+  4. Toggle "QuackForge (Test Mod)" ON (or restart)
+  5. Check logs:
+     - BepInEx/LogOutput.log
+     - ~/Library/Logs/TeamSoda/Duckov/Player.log
+
+Expected log line:
+  [QuackForge.TestMod] OnAfterSetup — hello from official Duckov mod path.
+NEXT

--- a/scripts/deploy-testmod-mac.sh
+++ b/scripts/deploy-testmod-mac.sh
@@ -21,7 +21,9 @@ PROJ_DIR="$REPO_ROOT/src/QuackForge.TestMod"
 BUILD_OUTPUT="$PROJ_DIR/bin/Release"
 
 DUCKOV_DIR="${DUCKOV_DIR:-$HOME/Library/Application Support/Steam/steamapps/common/Escape From Duckov}"
-MODS_DIR="$DUCKOV_DIR/Duckov.app/Contents/Resources/Data/Mods"
+# 덕코프의 Application.dataPath 는 <app>/Contents/ 를 반환하므로 Mods 는 그 바로 아래.
+# (일반 Unity Mac 빌드의 <app>/Contents/Resources/Data/ 와 다름 — 이 게임 고유 동작)
+MODS_DIR="$DUCKOV_DIR/Duckov.app/Contents/Mods"
 TARGET_DIR="$MODS_DIR/quackforge_test"
 
 SKIP_BUILD=0

--- a/src/QuackForge.TestMod/ModBehaviour.cs
+++ b/src/QuackForge.TestMod/ModBehaviour.cs
@@ -1,0 +1,41 @@
+using System;
+using UnityEngine;
+
+// 네임스페이스는 info.ini 의 name 값과 정확히 일치해야 함.
+// ModManager.ActivateMod 가 GetType("<name>.ModBehaviour") 로 조회.
+namespace quackforge_test
+{
+    public class ModBehaviour : Duckov.Modding.ModBehaviour
+    {
+        private const string Tag = "[QuackForge.TestMod]";
+
+        protected override void OnAfterSetup()
+        {
+            Debug.Log($"{Tag} OnAfterSetup — hello from official Duckov mod path.");
+            Debug.Log($"{Tag} ModInfo: name={info.name} version={info.version} isSteamItem={info.isSteamItem}");
+            Debug.Log($"{Tag} Unity.Application.dataPath = {Application.dataPath}");
+            Debug.Log($"{Tag} Mod folder = {info.path}");
+
+            // BepInEx 로 로드된 QuackForge.Core 와 공존 가능한지 체크.
+            // (같은 Unity 프로세스이므로 AppDomain 공유, AssemblyLoadContext 도 공유)
+            var appDomain = AppDomain.CurrentDomain;
+            var qfCore = appDomain.GetAssemblies();
+            int qfCount = 0;
+            foreach (var asm in qfCore)
+            {
+                var name = asm.GetName().Name;
+                if (name != null && name.StartsWith("QuackForge"))
+                {
+                    Debug.Log($"{Tag} sibling assembly: {name}");
+                    qfCount++;
+                }
+            }
+            Debug.Log($"{Tag} QuackForge.* assemblies in AppDomain: {qfCount} (>=1 → BepInEx 플러그인과 공존)");
+        }
+
+        protected override void OnBeforeDeactivate()
+        {
+            Debug.Log($"{Tag} OnBeforeDeactivate — cleanup.");
+        }
+    }
+}

--- a/src/QuackForge.TestMod/QuackForge.TestMod.csproj
+++ b/src/QuackForge.TestMod/QuackForge.TestMod.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    최소 공식 모드 엔트리포인트 (#65 실증용).
+
+    산출물: bin/Release/quackforge_test.dll
+    배포 경로: <Duckov.app>/Contents/Resources/Data/Mods/quackforge_test/
+               ├── info.ini
+               └── quackforge_test.dll
+
+    덕코프 ModManager 가:
+      Assembly.LoadFrom(...).GetType("quackforge_test.ModBehaviour")
+    를 호출하므로 AssemblyName = quackforge_test 로 고정 (케이스 민감).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>quackforge_test</AssemblyName>
+    <RootNamespace>quackforge_test</RootNamespace>
+    <Version>0.1.0</Version>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="TeamSoda.Duckov.Core">
+      <HintPath>$(DuckovManagedPath)\TeamSoda.Duckov.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DuckovManagedPath Condition="'$(DUCKOV_MANAGED_PATH)' != ''">$(DUCKOV_MANAGED_PATH)</DuckovManagedPath>
+    <DuckovManagedPath Condition="'$(DuckovManagedPath)' == ''">$(HOME)/Library/Application Support/Steam/steamapps/common/Escape From Duckov/Duckov.app/Contents/Resources/Data/Managed</DuckovManagedPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/QuackForge.TestMod/info.ini
+++ b/src/QuackForge.TestMod/info.ini
@@ -1,0 +1,6 @@
+name = quackforge_test
+displayName = QuackForge (Test Mod)
+description = Minimal official-mod-path verification for #65. Expected to log "hello from official Duckov mod path" on activation.\nBuilt from QuackForge repo src/QuackForge.TestMod. Safe to uninstall — no game state mutation.
+version = 0.1.0
+tags = quackforge,test,debug
+publishedFileId = 0


### PR DESCRIPTION
## Summary
덕코프 공식 모드 로드 경로(\`Duckov.Modding.ModManager\`) 가 실제로 작동하는지 검증하기 위한 최소 C# 모드.

## ✅ 실증 완료 (2026-04-22)

\`\`\`
Loading mod dll at path: /.../Duckov.app/Contents/Mods/quackforge_test/quackforge_test.dll
Mod Loaded: quackforge_test
[QuackForge.TestMod] OnAfterSetup — hello from official Duckov mod path.
[QuackForge.TestMod] Unity.Application.dataPath = /.../Duckov.app/Contents
[QuackForge.TestMod] Mod folder = /.../Contents/Mods/quackforge_test
[QuackForge.TestMod] sibling assembly: QuackForge.Loader
[QuackForge.TestMod] sibling assembly: QuackForge.Data
[QuackForge.TestMod] sibling assembly: QuackForge.Progression
[QuackForge.TestMod] sibling assembly: QuackForge.Core
[QuackForge.TestMod] QuackForge.* assemblies in AppDomain: 4
\`\`\`

## 확정된 사실 (#65 핵심 질문 전부 해소)

| 항목 | 결론 |
|---|---|
| 공식 모드 경로 | \`<app>/Contents/Mods/<name>/\` (주의: \`Application.dataPath\` = \`/Contents/\`, 일반 Unity Mac 빌드의 \`/Contents/Resources/Data/\` 와 다름) |
| info.ini 포맷 | 우리가 작성한 포맷 그대로 작동 — name/displayName/description 필수, version/tags/publishedFileId 선택 |
| DLL 로드 체인 | \`Assembly.LoadFrom\` → \`GetType("<name>.ModBehaviour")\` 정상 |
| ModBehaviour 인스턴스화 | \`GameObject.AddComponent\` + \`Setup\` + \`OnAfterSetup\` 호출 확인 |
| **BepInEx 공존** | ✅ 같은 AppDomain 에 4개 QuackForge 어셈블리 + quackforge_test 어셈블리 동시 존재. 하이브리드 배포 가능 |

## Artifact

\`\`\`
<Duckov.app>/Contents/Mods/quackforge_test/
├── info.ini             (name=quackforge_test, version=0.1.0)
└── quackforge_test.dll  (ModBehaviour, ~6KB)
\`\`\`

## 결정 영향

### 단기 (Phase 2-3)
BepInEx 유지 — 이미 검증됨, v0.1.0-alpha.1 릴리즈됨.

### v0.3 부터 가능해진 것
- **Steam Workshop 1-클릭 Subscribe 배포** (BepInEx 설치 없이)
- **인게임 모드 매니저 UI 통합** (현재는 BepInEx 플러그인이라 UI 목록에 안 나옴)
- **다른 모드와 priority 경합** 지원

### v0.3 래퍼 설계안
\`quackforge.dll\` 을 추가 빌드:
\`\`\`csharp
namespace quackforge {
    public class ModBehaviour : Duckov.Modding.ModBehaviour {
        protected override void OnAfterSetup() {
            QfCore.Initialize(...);  // QuackForge.Core 재사용
            // WeaponRegistry, ArmorRegistry, BlueprintRegistry, QfProgression...
        }
    }
}
\`\`\`
코드 대부분 공통 — 엔트리포인트만 다름.

## 변경 (이 PR)

- \`src/QuackForge.TestMod/\` : 최소 공식 모드 엔트리포인트 (ModBehaviour + info.ini + csproj)
- \`scripts/deploy-testmod-mac.sh\` : \`<app>/Contents/Mods/quackforge_test/\` 로 배포
- \`src/QuackForge.Loader/Diagnostics/ModPathProbe.cs\` : **삭제** (실증 완료 후 제거)

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] deploy-testmod-mac.sh 배포 성공
- [x] 인게임 Mods 메뉴 활성화 목록에 "QuackForge (Test Mod)" 등장
- [x] 약관 수락 + Mods 메뉴 재진입 시 \`OnAfterSetup\` 실행 로그 확인
- [x] BepInEx 플러그인과 AppDomain 공존 확인

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)