### PR TITLE
fix(#27): in-game integration fixes — Plugin host survival + Newtonsoft.Json

### DIFF
--- a/src/QuackForge.Core/QuackForge.Core.csproj
+++ b/src/QuackForge.Core/QuackForge.Core.csproj
@@ -14,7 +14,20 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- 게임이 이미 포함한 Newtonsoft.Json 참조. System.Text.Json 의 Utf8JsonWriter
+         가 Mono(Rosetta) 에서 VTable setup 실패하는 이슈 회피 (Phase 2 QA round 7). -->
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(DuckovManagedPath)\Newtonsoft.Json.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DuckovManagedPath Condition="'$(DUCKOV_MANAGED_PATH)' != ''">$(DUCKOV_MANAGED_PATH)</DuckovManagedPath>
+    <DuckovManagedPath Condition="'$(DuckovManagedPath)' == ''">$(HOME)/Library/Application Support/Steam/steamapps/common/Escape From Duckov/Duckov.app/Contents/Resources/Data/Managed</DuckovManagedPath>
+  </PropertyGroup>
 
 </Project>

--- a/src/QuackForge.Core/Save/QfSaveContext.cs
+++ b/src/QuackForge.Core/Save/QfSaveContext.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
+using Newtonsoft.Json;
 using QuackForge.Core.Logging;
 
 namespace QuackForge.Core.Save
@@ -21,10 +21,12 @@ namespace QuackForge.Core.Save
     // 복잡한 객체 (Dictionary<Enum, int> 등) 도 동작하도록 JsonSerializer 에 위임.
     public sealed class QfSaveContext
     {
-        private static readonly JsonSerializerOptions JsonOpts = new()
+        // Newtonsoft.Json: System.Text.Json.Utf8JsonWriter 가 Mono(Rosetta) 에서
+        // VTable setup 실패하는 이슈 회피 (Phase 2 QA round 7).
+        // 게임이 이미 Newtonsoft.Json.dll 을 포함하므로 추가 종속성 없음.
+        private static readonly JsonSerializerSettings JsonOpts = new()
         {
-            WriteIndented = true,
-            IncludeFields = true,
+            Formatting = Formatting.Indented,
         };
 
         private readonly string? _filePath;
@@ -48,7 +50,7 @@ namespace QuackForge.Core.Save
         public void Set<T>(string key, T value)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("key required", nameof(key));
-            var json = JsonSerializer.Serialize(value, typeof(T), JsonOpts);
+            var json = JsonConvert.SerializeObject(value, typeof(T), JsonOpts);
             lock (_lock)
             {
                 _store[key] = new Entry { TypeName = SimpleTypeName(typeof(T)), Json = json };
@@ -65,7 +67,7 @@ namespace QuackForge.Core.Save
                 {
                     try
                     {
-                        var parsed = JsonSerializer.Deserialize<T>(entry.Json, JsonOpts);
+                        var parsed = JsonConvert.DeserializeObject<T>(entry.Json, JsonOpts);
                         if (parsed != null)
                         {
                             value = parsed;
@@ -123,7 +125,7 @@ namespace QuackForge.Core.Save
                 if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
 
                 var tmp = _filePath + ".tmp";
-                var payload = JsonSerializer.Serialize(new FileFormat { Version = 1, Entries = snapshot }, JsonOpts);
+                var payload = JsonConvert.SerializeObject(new FileFormat { Version = 1, Entries = snapshot }, JsonOpts);
                 File.WriteAllText(tmp, payload);
                 if (File.Exists(_filePath)) File.Delete(_filePath);
                 File.Move(tmp, _filePath);
@@ -145,7 +147,7 @@ namespace QuackForge.Core.Save
             try
             {
                 var payload = File.ReadAllText(_filePath);
-                var parsed = JsonSerializer.Deserialize<FileFormat>(payload, JsonOpts);
+                var parsed = JsonConvert.DeserializeObject<FileFormat>(payload, JsonOpts);
                 if (parsed?.Entries == null) return;
 
                 lock (_lock)

--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -7,10 +7,11 @@ using QuackForge.Core;
 using QuackForge.Data.Armors;
 using QuackForge.Data.Blueprints;
 using QuackForge.Data.Weapons;
+using QuackForge.Loader.Runtime;
 using QuackForge.Loader.UI;
 using QuackForge.Progression;
-using QuackForge.Progression.Debug;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace QuackForge.Loader
 {
@@ -29,14 +30,16 @@ namespace QuackForge.Loader
         public static BlueprintRegistry Blueprints { get; private set; } = null!;
         public static QfProgression Progression { get; private set; } = null!;
 
-        private Harmony _harmony = null!;
+        // Harmony 인스턴스는 static. Plugin GameObject 가 죽어도 패치 자체는
+        // AppDomain 어셈블리에 살아남으므로 UnpatchSelf 를 호출하지 않는다.
+        private static Harmony? _harmony;
+        private static bool _runtimeAttached;
+
         private ConfigEntry<bool> _enableMod = null!;
         private ConfigEntry<bool> _debugOverlayEnabled = null!;
         private ConfigEntry<KeyboardShortcut> _debugAddXpKey = null!;
         private ConfigEntry<int> _debugAddXpAmount = null!;
         private ConfigEntry<float> _saveFlushIntervalSec = null!;
-
-        private float _nextFlushAt;
 
         private void Awake()
         {
@@ -98,36 +101,67 @@ namespace QuackForge.Loader
             // Harmony 패치가 Progression.Patches.* 를 등록한 뒤 Progression 초기화 (순서 의존 없음).
             Progression = QfProgression.Initialize(pointsPerLevel: 1, autoAllocateVit: true);
 
-            if (_debugOverlayEnabled.Value) DebugOverlay.Attach(this, Progression, core.Events);
+            // Phase 2 QA 발견:
+            //   Plugin GameObject 는 Duckov 부팅 막바지에 destroy 될 수 있다.
+            //   Plugin.Awake 시점엔 활성 scene 이 없어 DontDestroyOnLoad 도 무효.
+            //   매 프레임 로직(F9 키바인드, save flush) + DebugOverlay 는
+            //   첫 frame 이 돈 후에 별도 persistent host 로 attach.
+            //
+            //   Duckov 가 자체 mod 로더로 scene 을 갈아끼우면서 SceneManager.sceneLoaded
+            //   이벤트를 안 발화하는 케이스 (Round 3 확인) 가 있어 Update() fallback 도 둠.
+            //   둘 중 먼저 발화하는 쪽이 attach.
+            // Round 5 진단 발견:
+            //   Plugin GameObject 가 Awake → OnEnable → 즉시 OnDisable (active=False) 패턴.
+            //   Duckov 부팅 단계에서 BepInEx host GO 에 SetActive(false) 가 호출됨.
+            //   destroy 는 안 되지만 Update/Coroutine 도 안 돌고 sceneLoaded 도 못 받음.
+            //
+            //   해결: Awake 끝에서 즉시 별도 host GO 생성 + HideFlags.HideAndDontSave.
+            //   HideAndDontSave 는 Unity 의 unused asset cleanup / scene sweep 에서
+            //   GameObject 를 제외하므로 boot sweep 을 회피한다.
+            //   (BepInEx 5.4.21+ chainloader 가 동일 이유로 사용하는 패턴)
+            AttachRuntime("Awake");
 
-            _nextFlushAt = Time.realtimeSinceStartup + _saveFlushIntervalSec.Value;
+            // sceneLoaded fallback 은 유지 (host 도 어떻게든 죽으면 다음 scene 에서 재시도).
+            SceneManager.sceneLoaded += OnSceneLoaded;
 
-            Log.LogInfo($"\ud83e\udd86 {PluginName} is awake. Forging begins. (v{PluginVersion})");
+            Log.LogInfo($"🦆 {PluginName} bootstrapped (v{PluginVersion}).");
         }
 
-        private void Update()
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            if (_enableMod == null || !_enableMod.Value) return;
+            if (_runtimeAttached) return;
+            AttachRuntime($"sceneLoaded:{scene.name}");
+        }
 
-            // Debug: AddXp 키바인드
-            if (_debugAddXpKey != null && _debugAddXpKey.Value.IsDown())
+        private void AttachRuntime(string trigger)
+        {
+            if (_runtimeAttached) return;
+            _runtimeAttached = true;
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+
+            var host = new GameObject("QuackForge.Runtime");
+            // HideAndDontSave 가 boot sweep 회피의 핵심.
+            host.hideFlags = HideFlags.HideAndDontSave;
+            DontDestroyOnLoad(host);
+
+            var runtime = host.AddComponent<QfRuntime>();
+            runtime.Init(_debugAddXpKey, _debugAddXpAmount, _saveFlushIntervalSec);
+
+            if (_debugOverlayEnabled.Value)
             {
-                DebugCommands.AddXp(_debugAddXpAmount.Value);
+                DebugOverlay.Attach(runtime, Progression, QfCore.Instance!.Events);
             }
 
-            // 주기적 사이드카 flush
-            if (Time.realtimeSinceStartup >= _nextFlushAt)
-            {
-                QfCore.Instance?.Save.FlushIfDirty();
-                _nextFlushAt = Time.realtimeSinceStartup + _saveFlushIntervalSec.Value;
-            }
+            Log.LogInfo($"🦆 {PluginName} runtime attached (trigger={trigger}). Forging begins.");
         }
 
         private void OnDestroy()
         {
-            _harmony?.UnpatchSelf();
-            QfCore.Instance?.Save.FlushIfDirty();
-            Log?.LogInfo($"{PluginName} unloaded.");
+            // Plugin GameObject 는 Duckov 부팅 막바지에 destroy 되지만,
+            // 실제 런타임은 QfRuntime / DebugOverlay 별도 host 에 살아있으므로
+            // Harmony.UnpatchSelf 호출하지 않음 (패치를 살려둬야 함).
+            // sceneLoaded 미연결 상태면 cleanup.
+            SceneManager.sceneLoaded -= OnSceneLoaded;
         }
 
         private static string ResolveSaveFilePath()

--- a/src/QuackForge.Loader/Runtime/QfRuntime.cs
+++ b/src/QuackForge.Loader/Runtime/QfRuntime.cs
@@ -1,0 +1,63 @@
+using BepInEx.Configuration;
+using QuackForge.Core;
+using QuackForge.Core.Logging;
+using QuackForge.Progression.Debug;
+using UnityEngine;
+
+namespace QuackForge.Loader.Runtime
+{
+    // Phase 2 QA 발견:
+    //   Duckov 부팅 막바지에 BepInEx Chainloader 가 배치한 Plugin host GameObject 가
+    //   Resources.UnloadUnusedAssets / 첫 scene 로드 흐름에 휩쓸려 Destroy 된다.
+    //   Plugin.Awake 시점엔 활성 scene 이 아직 없어 DontDestroyOnLoad 도 무효.
+    //
+    // 해결:
+    //   매 프레임 로직(키바인드, 주기적 사이드카 flush)을 별도 GameObject 로 분리하고
+    //   첫 scene 이 로드된 후에 생성/등록해서 DontDestroyOnLoad 가 실효를 갖게 한다.
+    public sealed class QfRuntime : MonoBehaviour
+    {
+        private readonly IQfLog _log = QfLogger.For("Runtime");
+
+        private ConfigEntry<KeyboardShortcut>? _addXpKey;
+        private ConfigEntry<int>? _addXpAmount;
+        private ConfigEntry<float>? _flushIntervalSec;
+        private float _nextFlushAt;
+
+        public void Init(
+            ConfigEntry<KeyboardShortcut> addXpKey,
+            ConfigEntry<int> addXpAmount,
+            ConfigEntry<float> flushIntervalSec)
+        {
+            _addXpKey = addXpKey;
+            _addXpAmount = addXpAmount;
+            _flushIntervalSec = flushIntervalSec;
+            _nextFlushAt = Time.realtimeSinceStartup + flushIntervalSec.Value;
+            _log.Info($"runtime ready (addXpKey={addXpKey.Value}, flushInterval={flushIntervalSec.Value}s)");
+        }
+
+        private void Update()
+        {
+            if (_addXpKey != null && _addXpKey.Value.IsDown())
+            {
+                DebugCommands.AddXp(_addXpAmount!.Value);
+            }
+
+            if (_flushIntervalSec != null && Time.realtimeSinceStartup >= _nextFlushAt)
+            {
+                QfCore.Instance?.Save.FlushIfDirty();
+                _nextFlushAt = Time.realtimeSinceStartup + _flushIntervalSec.Value;
+            }
+        }
+
+        private void OnApplicationQuit()
+        {
+            QfCore.Instance?.Save.FlushIfDirty();
+        }
+
+        private void OnDestroy()
+        {
+            // Persistent GameObject 라 정상 게임 종료 외엔 호출되지 않아야 함.
+            QfCore.Instance?.Save.FlushIfDirty();
+        }
+    }
+}

--- a/src/QuackForge.Loader/UI/DebugOverlay.cs
+++ b/src/QuackForge.Loader/UI/DebugOverlay.cs
@@ -33,6 +33,8 @@ namespace QuackForge.Loader.UI
             if (_instance != null) return;
 
             var go = new GameObject("QuackForgeDebugOverlay");
+            // HideAndDontSave: Duckov 부팅 sweep 회피 (Plugin.AttachRuntime 주석 참조).
+            go.hideFlags = HideFlags.HideAndDontSave;
             DontDestroyOnLoad(go);
             _instance = go.AddComponent<DebugOverlay>();
             _instance._progression = progression;

--- a/src/QuackForge.Progression/Xp/XpSubscriber.cs
+++ b/src/QuackForge.Progression/Xp/XpSubscriber.cs
@@ -39,10 +39,19 @@ namespace QuackForge.Progression.Xp
 
         private void OnLevelChanged(int prev, int next)
         {
-            if (next <= prev) return; // 하향 조정은 포인트 반환 안 함 (Phase 2 범위 밖)
-            var gained = (next - prev) * _pointsPerLevel;
-            _log.Info($"level {prev} → {next} — granting {gained} stat points");
-            _stats.GrantPoints(gained, $"level {prev}→{next}");
+            // try/catch: 콜백에서 예외가 나면 게임의 EXPManager 가 다른 핸들러까지
+            // 끊어버릴 수 있으므로 invocation list 보호 차원에서 swallow + log.
+            try
+            {
+                if (next <= prev) return; // 하향 조정은 포인트 반환 안 함 (Phase 2 범위 밖)
+                var gained = (next - prev) * _pointsPerLevel;
+                _log.Info($"level {prev} → {next} — granting {gained} stat points");
+                _stats.GrantPoints(gained, $"level {prev}→{next}");
+            }
+            catch (Exception e)
+            {
+                _log.Error($"OnLevelChanged threw: {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
> 재발급 PR — 이전 PR #76 가 잘못된 base(main)로 머지되어 main revert + 새 base(develop) 로 재발급.

## Summary
Phase 2 인게임 QA(#27) 9 라운드 진단 결과, **v0.1.0-alpha.1 가 실제 인게임에서 한 번도 동작하지 않았음**이 드러남. 부트 라인까지는 정상이었지만 BepInEx Plugin GameObject 가 Duckov 부팅 sweep 에 걸려 매 프레임 로직(F9, save flush, IMGUI)이 모두 죽었고, 살아남았어도 사이드카 직렬화에서 `System.Text.Json` 이 Mono+Rosetta 환경에서 VTable 실패로 깨졌음.

## 발견 (round-by-round)

| Round | 발견 | 대응 |
|---|---|---|
| 1-2 | Plugin GO 가 Chainloader startup 직후 destroy. `DontDestroyOnLoad` 만으로는 무효 (활성 scene 없음) | (진단) |
| 3-4 | Update / `SceneManager.sceneLoaded` 콜백도 호출 안 됨 | (진단) |
| 5 | OnEnable → 즉시 OnDisable. Plugin GO 가 destroy 가 아닌 `SetActive(false)` 당함 | (진단) |
| 6 | `HideFlags.HideAndDontSave` 적용한 별도 host GO 가 sweep 우회 | ✅ |
| 7 | F9 체인 작동, `OnLevelChanged` 안에서 `System.Text.Json.Utf8JsonWriter` VTable setup 실패 | (진단) |
| 8 | Newtonsoft.Json 으로 교체 → 풀 체인 정상 | ✅ |
| 9 | 게임 재시작 후 `VIT=5` 복원 컨펌 | ✅ |

## 변경

- **`src/QuackForge.Loader/Runtime/QfRuntime.cs` (신규)**: F9 키바인드 + 주기적 사이드카 flush 를 별도 persistent host 로 분리.
- **`src/QuackForge.Loader/Plugin.cs`**: Awake 에서 즉시 `AttachRuntime("Awake")` → host GameObject 생성 (`HideFlags.HideAndDontSave` + `DontDestroyOnLoad`). `_harmony` static 변경 (Plugin GO 죽어도 패치 살려둬야 함). `Update`/flush 로직 제거 (QfRuntime 으로 이동). `SceneManager.sceneLoaded` fallback 유지.
- **`src/QuackForge.Loader/UI/DebugOverlay.cs`**: DebugOverlay GameObject 도 동일하게 `HideAndDontSave` 보호.
- **`src/QuackForge.Core/QuackForge.Core.csproj`**: `System.Text.Json 8.0.5` PackageReference 제거. 게임이 이미 포함한 `Newtonsoft.Json.dll` 직접 참조.
- **`src/QuackForge.Core/Save/QfSaveContext.cs`**: `JsonSerializer` / `Utf8JsonWriter` → `JsonConvert` (Newtonsoft.Json) 교체.
- **`src/QuackForge.Progression/Xp/XpSubscriber.cs`**: `OnLevelChanged` 에 try/catch 추가 — 콜백에서 throw 시 EXPManager 의 invocation list 가 끊기지 않도록 보호.

## 검증 (Round 8/9 인게임 로그)

```
[Runtime] runtime ready (addXpKey=F9, flushInterval=15s)
🦆 QuackForge runtime attached (trigger=Awake). Forging begins.

[Progression.Debug] AddXp(1000) — EXP 0 → 1000, Level=1
[Progression.Xp] level 1 → 2 — granting 1 stat points
[Progression.Stats] allocated +1 to VIT (now=1, unspent=0)
... (반복, VIT=5 까지 누적)

# 게임 재시작 후 (Round 9)
[Core.Save] loaded 1 entries from .../BepInEx/quackforge.json
[Progression.Stats] restored — unspent=0, VIT=5
```

- `quackforge.json` 정상 작성 (atomic tmp→target rename, 306B)
- HP 바 +50 (VIT 5 × +10) 시각 컨펌

## 알려진 잔여

- **DebugOverlay IMGUI 가 인게임 raid 중 cursor lock 을 깸.** 임시로 cfg `OverlayEnabled=false` 권장. 이슈 #77 로 트래킹.

## Test plan
- [x] dotnet build — 0 warn, 0 error
- [x] 인게임 부팅 → `runtime attached` + 우상단 IMGUI 정상 생성
- [x] F9 → AddXp → onLevelChanged → granting → allocated VIT 풀 체인
- [x] 15s 주기 flush 로 `quackforge.json` 작성
- [x] 게임 종료/재시작 후 VIT 값 복원
- [x] HP 바 시각 가산 (사용자 확인)
- [ ] Windows VM 동일 검증 (#27 cross-platform 일부)

Closes #27
Refs #19 #20 #23 #24 #25 #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)