### PR TITLE
release: v0.2.0-alpha.1 (Phase 2 closeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to QuackForge are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows [SemVer](https://semver.org/).
 
+## [0.2.0-alpha.1] — 2026-04-29
+
+Phase 2 closeout. Hybrid leveling 체인이 인게임에서 처음으로 동작. v0.1.0 의 **잘못 진단된 known issue** ("게임 종료 직후 unloaded") 가 사실은 부팅 단계의 Plugin GameObject sweep 이었음을 발견하고 fix.
+
+### Added
+- **`QuackForge.Progression`** 모듈 (#19 #20 #21).
+  - `StatType` enum (VIT/STR/AGI/PRE/SUR), `StatManager` (포인트 적립/분배/persist + 이벤트), `XpSubscriber` (`Duckov.EXPManager.onLevelChanged` 구독), `QfProgression` 컴포지션 루트.
+  - Hybrid 전략: XP/레벨 계산은 게임에 위임, 레벨업 이벤트만 우리가 활용 (PRD §6.0).
+  - `pointsPerLevel = 1`, `autoAllocateVit = true` (MVP — Phase 3 Character UI 진입 시 false 전환).
+- **HP 스탯 Harmony 패치** (#24): `Health.MaxHealth` Postfix — MainCharacter 한정 VIT × +10 가산. 인게임 +10 시각 컨펌.
+- **`QfRuntime` MonoBehaviour** — F9 키바인드 + 주기적 사이드카 flush. Plugin GameObject 와 분리된 persistent host 에 부착.
+- **사이드카 IO `quackforge.json`** (#23): atomic `tmp → target` rename, 15s 주기 flush, 게임 세이브와 분리. Newtonsoft.Json 사용.
+- **`DebugOverlay` IMGUI** (#25): 우상단 스탯 요약 + 3초 페이드 토스트. ⚠️ #77 (cursor lock 충돌) 로 cfg `OverlayEnabled = true` 기본이지만 raid 중엔 끌 것 권고.
+- **`AddXp` 디버그 키바인드** (#26): 기본 F9, 1000 XP/누름. `EXPManager.AddExp` 래핑.
+- **공식 Mod 경로 (`<app>/Contents/Mods/`) 실증** (#65): `QuackForge.TestMod` 최소 모드로 BepInEx 와 공존 가능 확인. v0.3 부터 `quackforge.dll` 공식 래퍼 후보.
+- **Unity 프로젝트 스캐폴드** (#65): `unity-project/` URP 2022.3.62f3 + `Assets/Editor/BuildAssetBundles.cs` + `scripts/build-mod.sh` (헤드리스). 실제 prefab 빌드는 후속.
+- **문서**: `docs/xp-balance.md` (XP/Level/Stat 곡선 + 정책), `docs/reverse-engineering/mod-system.md` (#74), `docs/assetbundle-workflow.md`.
+
+### Fixed (인게임 통합 — v0.1.0 결함)
+v0.1.0 가 인게임에서 한 번도 작동한 적 없었음 (#27 / PR #78, 9 라운드 진단):
+
+- **Plugin GameObject 가 부팅 sweep 으로 disable**. Duckov 가 BepInEx host GameObject 에 `SetActive(false)` 처리 → Update / sceneLoaded / 키바인드 모두 죽음. `DontDestroyOnLoad` 도 활성 scene 없는 시점이라 무효.
+  - **Fix**: 별도 host GameObject + `HideFlags.HideAndDontSave` + `DontDestroyOnLoad`. Plugin 은 부트스트랩만, 매 프레임 로직은 `QfRuntime` 으로 분리.
+- **Harmony 패치 OnDestroy 시 unpatch**. Plugin GO 가 죽으면 패치도 사라져 HP 가산 효과 소실.
+  - **Fix**: `_harmony` static, `OnDestroy` 의 `UnpatchSelf` 호출 제거.
+- **`System.Text.Json.Utf8JsonWriter` Mono+Rosetta 환경에서 VTable setup 실패**. 사이드카 직렬화 시 `TypeLoadException` → 후속 핸들러 체인 끊김.
+  - **Fix**: 게임 Managed/ 의 `Newtonsoft.Json.dll` 직접 참조, `JsonConvert` 로 교체 (Core 만, Data 의 boot-time deserialize 는 `Utf8JsonReader` 만 써서 영향 없음).
+- **XpSubscriber.OnLevelChanged unhandled exception 위험**. 콜백 throw 시 `EXPManager.onLevelChanged` invocation list 가 끊겨 다른 구독자(게임 자체 UI 등)도 같이 죽을 수 있음.
+  - **Fix**: try/catch + 로그.
+
+### Changed
+- **`QuackForge.Core` 의존성**: `System.Text.Json 8.0.5` PackageReference 제거 → `Newtonsoft.Json` (게임 제공) 직접 참조. (`QuackForge.Data` 는 boot-time deserialize 만 하므로 그대로 유지.)
+- **솔루션 5-프로젝트 구성**: `Loader` + `Core` + `Data` + `Progression` + `TestMod`.
+
+### Errata (v0.1.0 known issue 정정)
+v0.1.0 CHANGELOG 의 known issue 항목 중 **"게임 종료 직후 `Index was out of range`"** 는 **잘못된 진단**:
+- 사실 `QuackForge unloaded` 는 게임 부팅 막바지에 BepInEx Plugin GO 가 disable 되면서 발생하던 것 (종료 시점 아님). v0.2.0 에서 host 분리 fix 로 해소됐지만 BepInEx Plugin GO 자체는 여전히 disable 됨 (의도된 동작).
+- `Index was out of range` 콘솔 에러는 게임 자체의 raid 초기화 "Setting up pet" 단계 버그. 우리 모드와 무관, 게임 패치 전까지 무시 가능.
+
+### Known Issues / Deferred
+- **DebugOverlay IMGUI 가 raid 중 cursor lock 을 깸** (#77). 임시 회피: cfg `[Debug] OverlayEnabled = false`. Phase 3 #33 의 정식 UnityUI 로 deprecate 예정.
+- **무기 / 방어구 게임 내 spawn 미구현**. 데이터 카탈로그(메모리 등록) + 레벨 시스템까지만. 실제 prefab/AssetBundle 등록은 Phase 3 후속.
+- **Windows VM cross-platform 검증 미완**. PR #78 의 fix 가 BepInEx win_x64 에서도 같은 boot sweep / VTable 패턴이 나는지 별도 확인 필요.
+
+### Migration from v0.1.0-alpha.1
+- `BepInEx/quackforge.json` 포맷은 v0.1.0 과 동일 (있을 수 없지만, v0.1.0 이 인게임 동작 안 했으므로 사실상 신규 파일).
+- cfg `[Debug] OverlayEnabled` 기본값 `true` 유지. raid 진입 시 직접 `false` 로 끌 것 권고.
+
+[0.2.0-alpha.1]: https://github.com/noel88/quackforge/releases/tag/v0.2.0-alpha.1
+
 ## [0.1.0-alpha.1] — 2026-04-22
 
 First tagged alpha. 데이터 파이프라인 + 인프라 + Mac/VM 양쪽 end-to-end 로드 검증 완료. 실제 게임 내 아이템 스폰/제작은 AssetBundle 경로(#65) 후속.

--- a/docs/xp-balance.md
+++ b/docs/xp-balance.md
@@ -1,0 +1,59 @@
+# XP / Level / Stat 밸런스 (v0.2.0-alpha.1 시점)
+
+Phase 2 의 Hybrid leveling 전략 (PRD §6.0) 에 대한 실제 동작 + 밸런스 결정 기록.
+
+## 전략 요약
+
+XP 누적 / 레벨 계산 / 레벨업 알림은 **게임 (`Duckov.EXPManager`) 에 위임**. QuackForge 는 `EXPManager.onLevelChanged` 이벤트만 구독해서:
+
+1. 레벨업당 스탯 포인트 적립 (`pointsPerLevel = 1`)
+2. (MVP) `autoAllocateVit = true` → 새 포인트는 자동으로 VIT 에 투입
+3. VIT 변동 → Harmony Postfix → `Health.MaxHealth` 가산
+
+## 게임의 레벨 곡선 (실측)
+
+`EXPManager.levelExpDefinition` 은 Unity Inspector 에 직렬화된 `List<long>` 으로 디컴파일에선 값이 안 보이지만, F9 디버그 키 (`AddXp(1000)`) 반복으로 임계값 관찰:
+
+| Level | 누적 EXP 임계 | 레벨업까지 추가 EXP |
+|---:|---:|---:|
+| 1 → 2  | 2,000  | 2,000 |
+| 2 → 3  | 5,000  | 3,000 |
+| 3 → 4  | 9,000  | 4,000 |
+| 4 → 5  | 15,000 | 6,000 |
+| 5 → 6  | 21,000 | 6,000 |
+| 6 → 7  | 28,000 | 7,000 |
+| 7 → 8  | 36,000 | 8,000 |
+| 8 → 9  | 45,000 | 9,000 |
+| 9 → 10 | 55,000 | 10,000 |
+| 10 → 11 | 66,000 | 11,000 |
+| 11 → 12 | 78,000 | 12,000 |
+
+대략 **선형 + α** 곡선 (level n → n+1 이 약 n×1000 EXP). 추후 levelExpDefinition 전체 값을 게임 세이브 / Inspector dump 로 확인 가능.
+
+## QuackForge 의 스탯 정책 (현재)
+
+- **`pointsPerLevel = 1`**: 레벨업 1회 = 스탯 포인트 1점.
+- **`autoAllocateVit = true`**: 적립된 포인트는 즉시 VIT 에 투입. 분배 UI (#32) 가 나오면 false 로 전환 예정.
+- **VIT 1당 최대 HP +10** (Harmony `Health.MaxHealth` Postfix). 기본값. 추후 보스/서바이벌 빌드 차별화 시 조정 후보.
+- **STR / AGI / PRE / SUR** 정의는 enum 만 존재. 실 효과 패치는 Phase 3 #31 (스탯별 Harmony 패치 9종) 에서.
+
+## 관찰된 인게임 동작 (Round 8/9 QA 로그 기준)
+
+- F9 11회 (EXP 0 → 13000) 동안 레벨 4까지 도달. VIT=4 누적, HP +40 가산 시각 컨펌.
+- F9 더 누적 시 레벨 12까지 도달, VIT=11 + HP +110.
+- `quackforge.json` 사이드카에 `StatSnapshot { Unspent: 0, Allocated: { VIT: N } }` 영속.
+- 게임 종료/재시작 시 정확히 복원 (`[Progression.Stats] restored — unspent=0, VIT=N`).
+
+## 결정 메모
+
+- Hybrid 전략 = 게임 자체 레벨 곡선 (`levelExpDefinition`) 을 그대로 받아 모드의 밸런스 부담 최소화. 게임 패치 시 자동 동기화.
+- pointsPerLevel/autoAllocateVit 는 모두 `QfProgression.Initialize` 인자 — 후속 PR 에서 ConfigEntry 화 가능.
+- 레벨 다운(EXP 하향) 은 Phase 2 범위 밖. `XpSubscriber.OnLevelChanged` 에서 `next <= prev` 가드.
+- Stat 분배 UI (#32) 가 들어오면 autoAllocate 끄고 사용자 선택 권한 부여.
+
+## 후속 추적
+
+- `#31` 스탯별 Harmony 패치 9종 (STR → ItemWeight, AGI → MoveSpeed 등)
+- `#32` Character 탭 UI (수동 분배)
+- `#33` 레벨업 알림 UI (DebugOverlay → 정식 UnityUI 교체, #77 의 cursor 충돌도 같이 해결)
+- `#34` 설정 확장 (pointsPerLevel / autoAllocate / VIT→HP 비율 ConfigEntry 화)


### PR DESCRIPTION
## Summary
Phase 2 마무리 — CHANGELOG + `docs/xp-balance.md` + (PR 머지 후) `v0.2.0-alpha.1` 태깅.

## 포함 (PR 머지 시점에 develop 누적)
- PR #71-#75: Progression skeleton, sidecar IO, debug overlay/keybind, Unity scaffold, 공식 mod path 실증, RE 문서
- **PR #78 (#27): in-game integration fixes** — v0.1.0 가 인게임에서 한 번도 작동 안 했던 사실 + 9 라운드 진단 결과 + 5건 fix

## CHANGELOG 핵심 (v0.2.0-alpha.1)
- **Added**: `QuackForge.Progression` 모듈, HP Harmony 패치, `QfRuntime` host 분리, 사이드카 IO, DebugOverlay/AddXp, 공식 Mod path 실증, Unity scaffold
- **Fixed (인게임 통합 — v0.1.0 결함)**: Plugin GO sweep, Harmony unpatch, System.Text.Json VTable, OnLevelChanged unhandled exception
- **Errata**: v0.1.0 "게임 종료 직후 unloaded" → 사실은 부팅 단계 sweep. `Index out of range` → 게임 자체 pet 시스템 버그
- **Known issues**: #77 (DebugOverlay cursor), 무기/방어구 인게임 spawn 미구현, Windows VM cross-platform 미검증

## docs/xp-balance.md
- 게임 `levelExpDefinition` 곡선 실측 (Lv 1→12, F9 디버그 실측)
- QuackForge 의 스탯 정책 (`pointsPerLevel = 1`, `autoAllocateVit = true`, VIT × +10 HP)
- Phase 3 후속 추적 (#31 #32 #33 #34)

## 머지 후 절차
1. develop 에서 머지 commit (`db099e6` → 새 squash) hash 확인
2. `git tag v0.2.0-alpha.1 <sha>`
3. `git push origin v0.2.0-alpha.1`
4. (선택) `gh release create v0.2.0-alpha.1 --notes-from-tag --target develop`
5. #28 close

## Test plan
- [x] CHANGELOG 항목 빠짐 없음 검증
- [x] `docs/xp-balance.md` 실측 값 일관 (PR #78 Round 8 로그 대비)
- [ ] (사용자) PR 머지 → 태그 push → release 생성

Refs #28
🤖 Generated with [Claude Code](https://claude.com/claude-code)