### PR TITLE
feat(#31): 스탯별 Harmony 패치 5종 (STR/AGI/PRE/SUR — 1차)

### DIFF
--- a/src/QuackForge.Progression/Patches/CharacterMoveabilityPatch.cs
+++ b/src/QuackForge.Progression/Patches/CharacterMoveabilityPatch.cs
@@ -1,0 +1,37 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // AGI 1pt 당 이동 속도 +1% (multiplier).
+    //
+    // 대상: CharacterMainControl.CharacterMoveability getter
+    //   public float CharacterMoveability => GetFloatStatValue(moveabilityHash);
+    //
+    // 게임은 walk/run/turn 모두 이 값을 곱연산하므로 한 군데 패치로 모두 영향:
+    //   CharacterWalkSpeed = walkSpeed * CharacterMoveability * (gun.MoveSpeedMultiplier ...)
+    //   CharacterRunSpeed  = runSpeed  * CharacterMoveability * ...
+    //   CharacterTurnSpeed = turnSpeed * CharacterMoveability
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.CharacterMoveability), MethodType.Getter)]
+    public static class CharacterMoveabilityPatch
+    {
+        public const float MoveabilityPerAgiPct = 0.01f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var agi = _stats.GetAllocated(StatType.AGI);
+            if (agi <= 0) return;
+
+            __result *= 1f + agi * MoveabilityPerAgiPct;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/HealGainPatch.cs
+++ b/src/QuackForge.Progression/Patches/HealGainPatch.cs
@@ -1,0 +1,35 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // SUR 1pt 당 회복량 +5% (HealGain 가산).
+    //
+    // 대상: CharacterMainControl.HealGain getter
+    //
+    // 게임 내 사용 (Round 7 RE, line 7974):
+    //   health.AddHealth(healthValue * (1f + HealGain));
+    // → HealGain 이 +0.05×SUR 가산되면 회복량이 (1 + 기본 + 0.05×SUR) 배.
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.HealGain), MethodType.Getter)]
+    public static class HealGainPatch
+    {
+        public const float HealGainPerSurPct = 0.05f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var sur = _stats.GetAllocated(StatType.SUR);
+            if (sur <= 0) return;
+
+            __result += sur * HealGainPerSurPct;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/MaxStaminaPatch.cs
+++ b/src/QuackForge.Progression/Patches/MaxStaminaPatch.cs
@@ -1,0 +1,31 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // AGI 1pt 당 최대 스태미나 +3 (게임 stat "MaxStamina" 단위 그대로).
+    //
+    // 대상: CharacterMainControl.MaxStamina getter
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.MaxStamina), MethodType.Getter)]
+    public static class MaxStaminaPatch
+    {
+        public const float StaminaPerAgi = 3f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var agi = _stats.GetAllocated(StatType.AGI);
+            if (agi <= 0) return;
+
+            __result += agi * StaminaPerAgi;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/MaxWeightPatch.cs
+++ b/src/QuackForge.Progression/Patches/MaxWeightPatch.cs
@@ -1,0 +1,34 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // STR 1pt 당 캐리 용량 +0.5 (게임 stat "MaxWeight" 단위 그대로).
+    //
+    // 대상: CharacterMainControl.MaxWeight getter
+    //   public float MaxWeight {
+    //       get { return characterItem ? characterItem.GetStatValue(maxWeightHash) : 0f; }
+    //   }
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.MaxWeight), MethodType.Getter)]
+    public static class MaxWeightPatch
+    {
+        public const float WeightPerStr = 0.5f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var str = _stats.GetAllocated(StatType.STR);
+            if (str <= 0) return;
+
+            __result += str * WeightPerStr;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/RecoilControlPatch.cs
+++ b/src/QuackForge.Progression/Patches/RecoilControlPatch.cs
@@ -1,0 +1,35 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // PRE 1pt 당 RecoilControl +0.01 (multiplier 가산).
+    //
+    // 대상: CharacterMainControl.RecoilControl getter (default 1f, item stat 으로 보정)
+    //
+    // 게임 내 사용 (Round 7 RE):
+    //   recoilV = ... * (1f / gun.CharacterRecoilControl) * recoilMultiplier;
+    // → RecoilControl 값이 클수록 1/x 가 작아져 반동 감소.
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.RecoilControl), MethodType.Getter)]
+    public static class RecoilControlPatch
+    {
+        public const float RecoilControlPerPre = 0.01f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var pre = _stats.GetAllocated(StatType.PRE);
+            if (pre <= 0) return;
+
+            __result += pre * RecoilControlPerPre;
+        }
+    }
+}

--- a/src/QuackForge.Progression/QfProgression.cs
+++ b/src/QuackForge.Progression/QfProgression.cs
@@ -34,6 +34,14 @@ namespace QuackForge.Progression
             xp.Subscribe();
 
             HealthMaxHealthPatch.BindStats(stats);
+            // #31 — 5종 핵심 스탯 패치 binding (STR carry / AGI×2 / PRE / SUR).
+            // 나머지 4종 (MeleeDamage / GunScatter / EnergyCost / WaterCost) 은
+            // 시그니처 추가 RE 후 후속 PR.
+            MaxWeightPatch.BindStats(stats);
+            MaxStaminaPatch.BindStats(stats);
+            CharacterMoveabilityPatch.BindStats(stats);
+            RecoilControlPatch.BindStats(stats);
+            HealGainPatch.BindStats(stats);
 
             if (autoAllocateVit)
             {


### PR DESCRIPTION
## Summary
T3.3 / Phase 3 — 1차 PR. `docs/stat-balance.md` (#30) 매핑의 5종 핵심 패치. 나머지 4종 (MeleeDamage / GunScatter / EnergyCost / WaterCost) 은 시그니처 추가 RE 후 후속 PR.

## 패치 5종
| 파일 | Stat | 게임 게터 | 효과량 / pt |
|---|---|---|---|
| MaxWeightPatch | STR | `CharacterMainControl.MaxWeight` | +0.5 (가산) |
| MaxStaminaPatch | AGI | `CharacterMainControl.MaxStamina` | +3 (가산) |
| CharacterMoveabilityPatch | AGI | `CharacterMainControl.CharacterMoveability` | ×(1+0.01×AGI) |
| RecoilControlPatch | PRE | `CharacterMainControl.RecoilControl` | +0.01 (가산, 큰 값일수록 반동 ↓) |
| HealGainPatch | SUR | `CharacterMainControl.HealGain` | +0.05 (가산, 1+x multiplier 형) |

## 패턴
- HealthMaxHealthPatch (#24) 와 동일: Postfix + `IsMainCharacter` 가드 + `StatManager? _stats` + `BindStats(StatManager)` static
- 대상 namespace 는 `Duckov.CharacterMainControl` (VIT 의 `Health` 와 다름)
- QfProgression.Initialize 에서 5개 BindStats 호출 추가

## 빌드
- ✅ 0 warn, 0 error

## 미검증 (인게임 QA 필요)
현재 autoAllocate=true 로 모든 포인트 VIT 만 누적. STR/AGI/PRE/SUR 효과 검증을 위해선:
1. **#32 Character UI** 후 사용자 분배로 검증 (정식 경로)
2. 또는 `BepInEx/quackforge.json` 직접 편집해서 stat 값 강제 설정 → 게임 시작 시 복원되는 점 활용

본 PR 머지 후 별도 인게임 QA 라운드 권장.

## 후속
- 4종 추가 패치 (MeleeDamage / GunScatter / EnergyCost / WaterCost) — 별도 PR
- #32 Character UI

## Test plan
- [x] dotnet build clean
- [x] HealthMaxHealthPatch 패턴 일치
- [x] 모든 패치에 IsMainCharacter 가드
- [ ] (#32 또는 수동) 인게임 효과 검증 (5종 각각)

Refs #31 #30 (#31 close 는 나머지 4종 머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)