### PR TITLE
feat(#33): UnityUI LevelUpNotification + DebugOverlay deprecation (#77)

### DIFF
--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -37,6 +37,7 @@ namespace QuackForge.Loader
 
         private ConfigEntry<bool> _enableMod = null!;
         private ConfigEntry<bool> _debugOverlayEnabled = null!;
+        private ConfigEntry<bool> _levelUpNotificationEnabled = null!;
         private ConfigEntry<KeyboardShortcut> _debugAddXpKey = null!;
         private ConfigEntry<int> _debugAddXpAmount = null!;
         private ConfigEntry<float> _saveFlushIntervalSec = null!;
@@ -71,8 +72,16 @@ namespace QuackForge.Loader
             _debugOverlayEnabled = Config.Bind(
                 "Debug",
                 "OverlayEnabled",
+                false,
+                "DEPRECATED (issue #77): the IMGUI overlay breaks cursor lock during raids. " +
+                "Default OFF as of v0.3+. Use the UGUI Character panel + LevelUpNotification instead. " +
+                "Will be removed in v0.4.");
+
+            _levelUpNotificationEnabled = Config.Bind(
+                "Debug",
+                "LevelUpNotificationEnabled",
                 true,
-                "Show the IMGUI overlay (level-up toast + stat summary). Disable for release-like playtest.");
+                "Show the centered LEVEL UP! UnityUI overlay on level-up (replaces IMGUI toast).");
 
             _debugAddXpKey = Config.Bind(
                 "Debug",
@@ -244,6 +253,7 @@ namespace QuackForge.Loader
             }
 
             CharacterPanel.Attach(runtime, Progression, QfCore.Instance!.Events, _characterPanelKey);
+            LevelUpNotification.Attach(runtime, QfCore.Instance!.Events, _levelUpNotificationEnabled);
 
             Log.LogInfo($"🦆 {PluginName} runtime attached (trigger={trigger}). Forging begins.");
         }

--- a/src/QuackForge.Loader/UI/LevelUpNotification.cs
+++ b/src/QuackForge.Loader/UI/LevelUpNotification.cs
@@ -1,0 +1,145 @@
+using BepInEx.Configuration;
+using QuackForge.Core.Events;
+using QuackForge.Core.Logging;
+using QuackForge.Progression.Stats;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace QuackForge.Loader.UI
+{
+    // 레벨업 알림 UnityUI 오버레이.
+    //   - 화면 중앙 "LEVEL UP!" 라벨 1.5초 표시 + 페이드 아웃
+    //   - 같은 캔버스 우상단에 "+N pts" 뱃지 (페이드 아웃 동안)
+    //   - StatPointsGrantedEvent 구독 (game's onLevelChanged 와 1:1)
+    //
+    // host GameObject 는 별도 (HideAndDontSave + DontDestroyOnLoad). 게임 cursor lock
+    // 깨지 않도록 GraphicRaycaster 만 두고 PointerEvent 자체엔 무관 (raycastTarget=false).
+    //
+    // Sound (Q3-3) — 게임 내 UI 사운드 reflection 으로 호출하는 건 후속. 이번엔 미구현.
+    public sealed class LevelUpNotification : MonoBehaviour
+    {
+        private const float DisplaySec = 1.5f;
+        private const float FadeOutSec = 1.0f;
+
+        private static LevelUpNotification? _instance;
+
+        private readonly IQfLog _log = QfLogger.For("UI.LevelUp");
+
+        private GameObject? _root;
+        private CanvasGroup? _group;
+        private Text? _headerText;
+        private Text? _badgeText;
+
+        private float _hideAtRealtime = -1f;
+        private float _fadeStartRealtime = -1f;
+
+        public static void Attach(MonoBehaviour host, QfEventBus bus, ConfigEntry<bool>? enabled)
+        {
+            if (_instance != null) return;
+            if (enabled != null && !enabled.Value) return;
+
+            var go = new GameObject("QuackForgeLevelUpNotification");
+            go.hideFlags = HideFlags.HideAndDontSave;
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<LevelUpNotification>();
+
+            bus.Subscribe<StatPointsGrantedEvent>(_instance.OnPointsGranted);
+            _instance._log.Info("LevelUpNotification attached");
+        }
+
+        private void OnPointsGranted(StatPointsGrantedEvent evt)
+        {
+            if (_root == null) BuildUI();
+            if (_headerText != null) _headerText.text = "LEVEL UP!";
+            if (_badgeText != null) _badgeText.text = $"+{evt.Amount} pts";
+            _root!.SetActive(true);
+            if (_group != null) _group.alpha = 1f;
+            _hideAtRealtime = Time.realtimeSinceStartup + DisplaySec;
+            _fadeStartRealtime = _hideAtRealtime;
+        }
+
+        private void Update()
+        {
+            if (_root == null || !_root.activeSelf || _group == null) return;
+
+            var now = Time.realtimeSinceStartup;
+            if (now < _fadeStartRealtime) return;
+
+            var elapsed = now - _fadeStartRealtime;
+            if (elapsed >= FadeOutSec)
+            {
+                _group.alpha = 0f;
+                _root.SetActive(false);
+                return;
+            }
+            _group.alpha = 1f - elapsed / FadeOutSec;
+        }
+
+        private void BuildUI()
+        {
+            _root = new GameObject("LevelUpRoot");
+            _root.hideFlags = HideFlags.HideAndDontSave;
+            _root.transform.SetParent(transform);
+
+            var canvas = _root.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = 1100; // CharacterPanel 위
+            _root.AddComponent<CanvasScaler>();
+            // GraphicRaycaster 추가 안 함 — PointerEvent 미수신 (cursor lock 비간섭).
+            _group = _root.AddComponent<CanvasGroup>();
+            _group.blocksRaycasts = false;
+            _group.interactable = false;
+
+            // 중앙 헤더
+            _headerText = CreateText("HeaderText", "LEVEL UP!", 36, FontStyle.Bold, new Color(1f, 0.85f, 0.35f, 1f), TextAnchor.MiddleCenter);
+            var headerRect = _headerText.GetComponent<RectTransform>();
+            headerRect.anchorMin = new Vector2(0.5f, 0.5f);
+            headerRect.anchorMax = new Vector2(0.5f, 0.5f);
+            headerRect.pivot = new Vector2(0.5f, 0.5f);
+            headerRect.anchoredPosition = new Vector2(0f, 60f);
+            headerRect.sizeDelta = new Vector2(420f, 80f);
+
+            // 우상단 뱃지
+            _badgeText = CreateText("BadgeText", "+0 pts", 18, FontStyle.Bold, new Color(0.7f, 1f, 0.7f, 1f), TextAnchor.MiddleCenter);
+            var badgeRect = _badgeText.GetComponent<RectTransform>();
+            badgeRect.anchorMin = new Vector2(1f, 1f);
+            badgeRect.anchorMax = new Vector2(1f, 1f);
+            badgeRect.pivot = new Vector2(1f, 1f);
+            badgeRect.anchoredPosition = new Vector2(-24f, -24f);
+            badgeRect.sizeDelta = new Vector2(140f, 40f);
+
+            _root.SetActive(false);
+            _log.Info("LevelUpNotification UI built");
+        }
+
+        private Text CreateText(string name, string content, int size, FontStyle style, Color color, TextAnchor anchor)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root!.transform, false);
+
+            var text = go.AddComponent<Text>();
+            text.text = content;
+            text.font = GetFont();
+            text.fontSize = size;
+            text.fontStyle = style;
+            text.color = color;
+            text.alignment = anchor;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false; // cursor lock 비간섭
+            return text;
+        }
+
+        private static Font? _cachedFont;
+        private static Font GetFont()
+        {
+            if (_cachedFont != null) return _cachedFont;
+            _cachedFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            if (_cachedFont != null) return _cachedFont;
+            _cachedFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            if (_cachedFont != null) return _cachedFont;
+            _cachedFont = Font.CreateDynamicFontFromOSFont("Arial", 36);
+            return _cachedFont;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
T3.5 — 화면 중앙 "LEVEL UP!" 오버레이 + 우상단 "+N pts" 뱃지 (UGUI). DebugOverlay 의 IMGUI 토스트 역할을 흡수하므로 `[Debug] OverlayEnabled` 기본값 `false` 로 변경 + v0.4 제거 예고. **#77 (cursor lock 충돌) 자연 해소**.

## 추가
- **`src/QuackForge.Loader/UI/LevelUpNotification.cs`** (신규):
  - host GameObject 별도 (`HideAndDontSave` + `DontDestroyOnLoad`)
  - `StatPointsGrantedEvent` 구독 → 중앙 "LEVEL UP!" + 우상단 "+N pts"
  - 1.5s 표시 + 1.0s 페이드 아웃 (CanvasGroup.alpha 트윈)
  - Canvas `sortingOrder=1100` (CharacterPanel 위)
  - **GraphicRaycaster 미부착 + raycastTarget=false** → cursor lock 비간섭 (#77 회피)
- **ConfigEntry**: `[Debug] LevelUpNotificationEnabled` (default `true`)

## 변경
- `[Debug] OverlayEnabled` default `true` → `false`. Description 에 deprecate + v0.4 제거 명시
- `Plugin.AttachRuntime`: `LevelUpNotification.Attach` 추가

## 빌드
- ✅ 0 warn, 0 error

## 검증 (인게임 라운드)
- [ ] F9 → 레벨업 → 화면 중앙 "LEVEL UP!" + 우상단 "+1 pts" 1.5s + 페이드
- [ ] cursor lock 정상 (UGUI raycastTarget=false 효과 확인)
- [ ] DebugOverlay 자동 OFF (신규 cfg 기본값) — 기존 사용자는 cfg 그대로
- [ ] LevelUpNotificationEnabled=false 로 끄면 미표시

## Q3-3 (Sound) — 미구현
게임 UI 사운드 reflection 호출은 Phase 5 폴리싱에서.

## 후속
- #77 close 는 인게임 검증 + cursor 정상 확인 후
- 사운드 (Q3-3)
- 한 번에 묶어 v0.3.0-alpha.1 (#37) 태깅

## Test plan
- [x] dotnet build clean
- [x] LevelUpNotification host GO 패턴 일치 (CharacterPanel/DebugOverlay)
- [x] StatPointsGrantedEvent 구독
- [ ] (사용자) 인게임 표시 + 페이드 + cursor 정상 검증

Closes #33
Refs #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)