### PR TITLE
feat(#31): 잔여 4종 스탯 패치 (Melee/GunScatter/EnergyCost/WaterCost) — 9-patch full set

### DIFF
--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -51,6 +51,11 @@ namespace QuackForge.Loader
         private ConfigEntry<float> _moveabilityPerAgiPct = null!;
         private ConfigEntry<float> _recoilControlPerPre = null!;
         private ConfigEntry<float> _healGainPerSurPct = null!;
+        private ConfigEntry<float> _meleeDamagePerStrPct = null!;
+        private ConfigEntry<float> _scatterReducePerPrePct = null!;
+        private ConfigEntry<float> _scatterFloor = null!;
+        private ConfigEntry<float> _costReducePerSurPct = null!;
+        private ConfigEntry<float> _costFloor = null!;
         private ConfigEntry<KeyboardShortcut> _characterPanelKey = null!;
 
         private void Awake()
@@ -162,6 +167,36 @@ namespace QuackForge.Loader
                 0.05f,
                 "HealGain bonus per SUR point (0.05 = +5%).");
 
+            _meleeDamagePerStrPct = Config.Bind(
+                "Effects",
+                "MeleeDamagePerStrPct",
+                0.02f,
+                "MeleeDamageMultiplier bonus per STR point (0.02 = +2%, 가산).");
+
+            _scatterReducePerPrePct = Config.Bind(
+                "Effects",
+                "ScatterReducePerPrePct",
+                0.015f,
+                "GunScatter multiplier reduction per PRE point (0.015 = -1.5%, 곱연산).");
+
+            _scatterFloor = Config.Bind(
+                "Effects",
+                "ScatterFloor",
+                0.1f,
+                "Minimum GunScatter multiplier after PRE reduction (0.1 = 90% reduction floor).");
+
+            _costReducePerSurPct = Config.Bind(
+                "Effects",
+                "CostReducePerSurPct",
+                0.03f,
+                "Energy/Water cost reduction per SUR point (0.03 = -3%, 곱연산, 음식과 물 동일).");
+
+            _costFloor = Config.Bind(
+                "Effects",
+                "CostFloor",
+                0.1f,
+                "Minimum Energy/Water cost multiplier after SUR reduction.");
+
             _characterPanelKey = Config.Bind(
                 "Debug",
                 "CharacterPanelKey",
@@ -199,6 +234,11 @@ namespace QuackForge.Loader
                 MoveabilityPerAgiPct = _moveabilityPerAgiPct.Value,
                 RecoilControlPerPre = _recoilControlPerPre.Value,
                 HealGainPerSurPct = _healGainPerSurPct.Value,
+                MeleeDamagePerStrPct = _meleeDamagePerStrPct.Value,
+                ScatterReducePerPrePct = _scatterReducePerPrePct.Value,
+                ScatterFloor = _scatterFloor.Value,
+                CostReducePerSurPct = _costReducePerSurPct.Value,
+                CostFloor = _costFloor.Value,
             });
 
             // Phase 2 QA 발견:

--- a/src/QuackForge.Progression/Patches/EnergyCostPerMinPatch.cs
+++ b/src/QuackForge.Progression/Patches/EnergyCostPerMinPatch.cs
@@ -1,0 +1,42 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+using UnityEngine;
+
+namespace QuackForge.Progression.Patches
+{
+    // SUR 1pt 당 음식(에너지) 소비 -3%.
+    //
+    // 대상: CharacterMainControl.EnergyCostPerMin getter
+    //   (분당 energy 소비. 작을수록 음식 오래감)
+    //   곱연산 형: __result *= (1 - 0.03×SUR), floor 0.1 (90% 감소까지).
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.EnergyCostPerMin), MethodType.Getter)]
+    public static class EnergyCostPerMinPatch
+    {
+        public static float CostReducePerSurPct { get; set; } = 0.03f;
+        public static float CostFloor { get; set; } = 0.1f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        public static void BindConfig(float costReducePerSurPct, float costFloor)
+        {
+            CostReducePerSurPct = costReducePerSurPct;
+            CostFloor = costFloor;
+        }
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var sur = _stats.GetAllocated(StatType.SUR);
+            if (sur <= 0) return;
+
+            var multiplier = 1f - sur * CostReducePerSurPct;
+            __result *= Mathf.Max(multiplier, CostFloor);
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/GunScatterMultiplierPatch.cs
+++ b/src/QuackForge.Progression/Patches/GunScatterMultiplierPatch.cs
@@ -1,0 +1,42 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+using UnityEngine;
+
+namespace QuackForge.Progression.Patches
+{
+    // PRE 1pt 당 사격 정확도 +1.5% (산발 -1.5%).
+    //
+    // 대상: CharacterMainControl.GunScatterMultiplier getter
+    //   (default 1f, 작은 값일수록 정확. 곱연산 형: __result *= (1 - 0.015×PRE))
+    //   극단값 방지를 위해 floor 가드 (기본 0.1).
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.GunScatterMultiplier), MethodType.Getter)]
+    public static class GunScatterMultiplierPatch
+    {
+        public static float ScatterReducePerPrePct { get; set; } = 0.015f;
+        public static float ScatterFloor { get; set; } = 0.1f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        public static void BindConfig(float scatterReducePerPrePct, float scatterFloor)
+        {
+            ScatterReducePerPrePct = scatterReducePerPrePct;
+            ScatterFloor = scatterFloor;
+        }
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var pre = _stats.GetAllocated(StatType.PRE);
+            if (pre <= 0) return;
+
+            var multiplier = 1f - pre * ScatterReducePerPrePct;
+            __result *= Mathf.Max(multiplier, ScatterFloor);
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/MeleeDamageMultiplierPatch.cs
+++ b/src/QuackForge.Progression/Patches/MeleeDamageMultiplierPatch.cs
@@ -1,0 +1,34 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+
+namespace QuackForge.Progression.Patches
+{
+    // STR 1pt 당 근접 데미지 +2% (가산).
+    //
+    // 대상: CharacterMainControl.MeleeDamageMultiplier getter
+    //   (default 0f. 게임이 damage * (1 + multiplier) 식으로 호출하므로 +0.02×STR 가산
+    //    = STR 1pt 당 +2% 근접 데미지)
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.MeleeDamageMultiplier), MethodType.Getter)]
+    public static class MeleeDamageMultiplierPatch
+    {
+        public static float MeleeDamagePerStrPct { get; set; } = 0.02f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+        public static void BindConfig(float meleeDamagePerStrPct) => MeleeDamagePerStrPct = meleeDamagePerStrPct;
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var str = _stats.GetAllocated(StatType.STR);
+            if (str <= 0) return;
+
+            __result += str * MeleeDamagePerStrPct;
+        }
+    }
+}

--- a/src/QuackForge.Progression/Patches/WaterCostPerMinPatch.cs
+++ b/src/QuackForge.Progression/Patches/WaterCostPerMinPatch.cs
@@ -1,0 +1,42 @@
+using Duckov;
+using HarmonyLib;
+using QuackForge.Progression.Stats;
+using UnityEngine;
+
+namespace QuackForge.Progression.Patches
+{
+    // SUR 1pt 당 갈증(물) 소비 -3%.
+    //
+    // 대상: CharacterMainControl.WaterCostPerMin getter
+    //   (분당 water 소비. 작을수록 물 오래감)
+    //   곱연산 형: __result *= (1 - 0.03×SUR), floor 0.1.
+    [HarmonyPatch(typeof(CharacterMainControl), nameof(CharacterMainControl.WaterCostPerMin), MethodType.Getter)]
+    public static class WaterCostPerMinPatch
+    {
+        public static float CostReducePerSurPct { get; set; } = 0.03f;
+        public static float CostFloor { get; set; } = 0.1f;
+
+        private static StatManager? _stats;
+
+        public static void BindStats(StatManager stats) => _stats = stats;
+
+        public static void BindConfig(float costReducePerSurPct, float costFloor)
+        {
+            CostReducePerSurPct = costReducePerSurPct;
+            CostFloor = costFloor;
+        }
+
+        [HarmonyPostfix]
+        public static void Postfix(CharacterMainControl __instance, ref float __result)
+        {
+            if (_stats == null) return;
+            if (!__instance.IsMainCharacter) return;
+
+            var sur = _stats.GetAllocated(StatType.SUR);
+            if (sur <= 0) return;
+
+            var multiplier = 1f - sur * CostReducePerSurPct;
+            __result *= Mathf.Max(multiplier, CostFloor);
+        }
+    }
+}

--- a/src/QuackForge.Progression/ProgressionSettings.cs
+++ b/src/QuackForge.Progression/ProgressionSettings.cs
@@ -15,9 +15,14 @@ namespace QuackForge.Progression
         // [Effects] — 1포인트당 효과량
         public int HpPerVit { get; set; } = 10;
         public float WeightPerStr { get; set; } = 0.5f;
+        public float MeleeDamagePerStrPct { get; set; } = 0.02f;
         public float StaminaPerAgi { get; set; } = 3f;
         public float MoveabilityPerAgiPct { get; set; } = 0.01f;
         public float RecoilControlPerPre { get; set; } = 0.01f;
+        public float ScatterReducePerPrePct { get; set; } = 0.015f;
+        public float ScatterFloor { get; set; } = 0.1f;
         public float HealGainPerSurPct { get; set; } = 0.05f;
+        public float CostReducePerSurPct { get; set; } = 0.03f;
+        public float CostFloor { get; set; } = 0.1f;
     }
 }

--- a/src/QuackForge.Progression/QfProgression.cs
+++ b/src/QuackForge.Progression/QfProgression.cs
@@ -53,6 +53,15 @@ namespace QuackForge.Progression
             RecoilControlPatch.BindConfig(settings.RecoilControlPerPre);
             HealGainPatch.BindStats(stats);
             HealGainPatch.BindConfig(settings.HealGainPerSurPct);
+            // 잔여 4종 (#31 PR B)
+            MeleeDamageMultiplierPatch.BindStats(stats);
+            MeleeDamageMultiplierPatch.BindConfig(settings.MeleeDamagePerStrPct);
+            GunScatterMultiplierPatch.BindStats(stats);
+            GunScatterMultiplierPatch.BindConfig(settings.ScatterReducePerPrePct, settings.ScatterFloor);
+            EnergyCostPerMinPatch.BindStats(stats);
+            EnergyCostPerMinPatch.BindConfig(settings.CostReducePerSurPct, settings.CostFloor);
+            WaterCostPerMinPatch.BindStats(stats);
+            WaterCostPerMinPatch.BindConfig(settings.CostReducePerSurPct, settings.CostFloor);
 
             if (settings.AutoAllocateVit)
             {


### PR DESCRIPTION
## Summary
T3.3 #31 closeout. PR #82 의 5종 + 이번 4종 = PRD §7.4.2 의 **9종 패치 풀 셋 완성**.

## 패치 4종
| 파일 | Stat | 게임 게터 | 효과 / pt | 패턴 |
|---|---|---|---|---|
| MeleeDamageMultiplierPatch | STR | `CharacterMainControl.MeleeDamageMultiplier` | +0.02 (가산) | default 0f |
| GunScatterMultiplierPatch | PRE | `CharacterMainControl.GunScatterMultiplier` | ×(1−0.015×PRE), floor 0.1 | default 1f, 작을수록 정확 |
| EnergyCostPerMinPatch | SUR | `CharacterMainControl.EnergyCostPerMin` | ×(1−0.03×SUR), floor 0.1 | 분당 소비, 작을수록 오래감 |
| WaterCostPerMinPatch | SUR | `CharacterMainControl.WaterCostPerMin` | 동일 | 동일 |

## 추가 RE 결정
- `MeleeDamageMultiplier` default `0f` → 가산형 (`+= STR × 0.02`)
- `GunScatterMultiplier` default `1f` → 곱연산 (`*= 1 - PRE × 0.015`)
- `EnergyCost` / `WaterCost` 분당 소비 → 곱연산 (`*= 1 - SUR × 0.03`)
- 곱연산 패치엔 **floor 가드** (50pt 시 음수/0 방지). ConfigEntry 로 조정 가능.

## 변경
- `ProgressionSettings`: 5개 신규 필드
- `QfProgression.Initialize`: 4개 신규 BindStats + BindConfig
- Plugin: `[Effects]` ConfigEntry 5개 추가

## 빌드
- ✅ 0 warn, 0 error

## 9-patch 풀 셋
- VIT × 1: HP
- STR × 2: 캐리, **근접 데미지** (NEW)
- AGI × 2: 스태미나, 이속
- PRE × 2: 반동, **정확도** (NEW)
- SUR × 3: 회복, **음식**, **물** (NEW × 2)

## 미검증 (인게임 라운드 필요)
- [ ] STR +X → 근접 데미지 X×2% 증가
- [ ] PRE +X → GunScatter X×1.5% 감소 (정확도 ↑)
- [ ] SUR +X → 음식/물 소비 X×3% 감소
- [ ] floor 가드 동작 (PRE/SUR 50pt 시 floor 0.1 까지만)

## Test plan
- [x] dotnet build clean
- [x] 4종 패치 시그니처 + 패턴 RE 일치
- [x] floor 가드 (Mathf.Max)
- [ ] (사용자) 인게임 stat 분배 → 효과 시각/체감 검증

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)