### PR TITLE
feat(#32): ViewTabs Harmony-free 인젝트 — Char 탭 (PR B)

### DIFF
--- a/src/QuackForge.Loader/Plugin.cs
+++ b/src/QuackForge.Loader/Plugin.cs
@@ -294,6 +294,7 @@ namespace QuackForge.Loader
 
             CharacterPanel.Attach(runtime, Progression, QfCore.Instance!.Events, _characterPanelKey);
             LevelUpNotification.Attach(runtime, QfCore.Instance!.Events, _levelUpNotificationEnabled);
+            CharacterTabInjector.Initialize();
 
             Log.LogInfo($"🦆 {PluginName} runtime attached (trigger={trigger}). Forging begins.");
         }

--- a/src/QuackForge.Loader/QuackForge.Loader.csproj
+++ b/src/QuackForge.Loader/QuackForge.Loader.csproj
@@ -32,6 +32,11 @@
       <HintPath>$(DuckovManagedPath)\UnityEngine.UI.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <!-- TeamSoda.Duckov.Core: ViewTabs / ViewTabDisplayEntry / ManagedUIElement 인젝트용 (#32 PR B). -->
+    <Reference Include="TeamSoda.Duckov.Core">
+      <HintPath>$(DuckovManagedPath)\TeamSoda.Duckov.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/QuackForge.Loader/UI/CharacterPanel.cs
+++ b/src/QuackForge.Loader/UI/CharacterPanel.cs
@@ -20,6 +20,7 @@ namespace QuackForge.Loader.UI
     public sealed class CharacterPanel : MonoBehaviour
     {
         private static CharacterPanel? _instance;
+        public static CharacterPanel? Instance => _instance;
 
         private readonly IQfLog _log = QfLogger.For("UI.CharacterPanel");
 

--- a/src/QuackForge.Loader/UI/CharacterTabInjector.cs
+++ b/src/QuackForge.Loader/UI/CharacterTabInjector.cs
@@ -1,0 +1,116 @@
+using System;
+using Duckov.UI;
+using QuackForge.Core.Logging;
+using UnityEngine;
+using UnityEngine.UI;
+// ViewTabs / ViewTabDisplayEntry 는 global namespace (Duckov 네임스페이스 외부).
+
+namespace QuackForge.Loader.UI
+{
+    // #32 PR B — 게임 ViewTabs 에 "Char" 탭 인젝트.
+    //
+    // 전략 (낮은 위험):
+    //   1. ManagedUIElement.onOpen 구독 → 어떤 View 든 처음 열릴 때 ViewTabs scene 활성 보장
+    //   2. ViewTabs 자식의 ViewTabDisplayEntry prefab 1개 클론 (시각/스타일 보존)
+    //   3. 클론에서 ViewTabDisplayEntry 컴포넌트 제거 (원본 viewTypeName 추적 단절)
+    //   4. Button.onClick 리스너 교체 → CharacterPanel.Toggle()
+    //   5. 라벨 텍스트 "Char" 로 변경 (UGUI Text + TMPro reflection 양쪽)
+    //
+    // 인디케이터 (탭 활성 표시) 동기화는 우리 CharacterPanel 이 ManagedUIElement 가
+    // 아니라서 자동 동작 X. 후속 PR 에서 fake View 로 sync 가능.
+    public static class CharacterTabInjector
+    {
+        private static readonly IQfLog Log = QfLogger.For("UI.CharacterTab");
+
+        private static GameObject? _injected;
+        private static bool _initialized;
+
+        public static void Initialize()
+        {
+            if (_initialized) return;
+            _initialized = true;
+            ManagedUIElement.onOpen += OnAnyOpen;
+            Log.Info("CharacterTabInjector listening for first View open");
+        }
+
+        private static void OnAnyOpen(ManagedUIElement el)
+        {
+            if (_injected != null) return;
+            try
+            {
+                var tabs = UnityEngine.Object.FindObjectOfType<ViewTabs>(includeInactive: true);
+                if (tabs == null)
+                {
+                    Log.Debug($"OnOpen({el?.GetType().Name}) — no ViewTabs in scene yet");
+                    return;
+                }
+                Inject(tabs);
+            }
+            catch (Exception e)
+            {
+                Log.Error($"injector threw — disabling future attempts: {e}");
+                _injected = new GameObject("QuackForge.CharacterTab.failed"); // sentinel
+            }
+        }
+
+        private static void Inject(ViewTabs tabs)
+        {
+            var entries = tabs.GetComponentsInChildren<ViewTabDisplayEntry>(includeInactive: true);
+            if (entries == null || entries.Length == 0)
+            {
+                Log.Warn("ViewTabs found but no ViewTabDisplayEntry children — abort inject");
+                return;
+            }
+
+            var template = entries[0];
+            var container = template.transform.parent;
+            if (container == null)
+            {
+                Log.Warn("template entry has no parent — abort inject");
+                return;
+            }
+
+            var clone = UnityEngine.Object.Instantiate(template.gameObject, container);
+            clone.name = "QuackForge.CharacterTab";
+
+            // 클론된 ViewTabDisplayEntry 제거 — 원본 viewTypeName 추적 단절.
+            var entryComp = clone.GetComponent<ViewTabDisplayEntry>();
+            if (entryComp != null) UnityEngine.Object.Destroy(entryComp);
+
+            // Button click 리스너 교체.
+            var btn = clone.GetComponentInChildren<Button>(includeInactive: true);
+            if (btn != null)
+            {
+                btn.onClick.RemoveAllListeners();
+                btn.onClick.AddListener(() => CharacterPanel.Instance?.Toggle());
+            }
+            else
+            {
+                Log.Warn("clone has no Button child — click won't fire (visual only)");
+            }
+
+            // 라벨 텍스트 변경. UGUI Text + TMPro 양쪽 시도.
+            UpdateLabels(clone, "Char");
+
+            _injected = clone;
+            Log.Info($"injected Character tab into ViewTabs (under {container.name})");
+        }
+
+        private static void UpdateLabels(GameObject root, string newText)
+        {
+            // UGUI Text
+            foreach (var t in root.GetComponentsInChildren<Text>(includeInactive: true))
+                t.text = newText;
+
+            // TMPro (reflection — Loader 가 TMPro 직접 참조 안 하도록).
+            foreach (var c in root.GetComponentsInChildren<MonoBehaviour>(includeInactive: true))
+            {
+                if (c == null) continue;
+                var type = c.GetType();
+                if (type.Name != "TextMeshProUGUI" && type.Name != "TextMeshPro") continue;
+                var prop = type.GetProperty("text");
+                prop?.SetValue(c, newText, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
T3.4 PR B — 게임 ViewTabs 에 "Char" 탭을 동적으로 추가. **Harmony 패치 없이** ManagedUIElement.onOpen 이벤트 + clone-existing-entry 패턴으로 위험 최소화.

## 추가
- **`src/QuackForge.Loader/UI/CharacterTabInjector.cs`** (신규):
  - `ManagedUIElement.onOpen` 구독 → 첫 View 열릴 때 ViewTabs scene 활성 보장
  - `ViewTabs` 자식의 `ViewTabDisplayEntry` prefab 1개 클론 (시각/스타일 보존)
  - 클론에서 `ViewTabDisplayEntry` 컴포넌트 제거 (원본 viewTypeName 추적 단절)
  - Button.onClick 리스너 교체 → `CharacterPanel.Toggle()`
  - 라벨 "Char" 변경 (UGUI Text + TMPro reflection 양쪽)
  - 1회만 실행 (sentinel `_injected` 가드)
  - try/catch + 실패 시 sentinel 처리 — 게임 본 UI 깨짐 방지
- `CharacterPanel.Instance` 정적 프로퍼티 노출

## 변경
- `Loader.csproj`: `TeamSoda.Duckov.Core` 직접 참조 추가
- `Plugin.AttachRuntime`: `CharacterTabInjector.Initialize()` 호출

## 빌드
- ✅ 0 warn, 0 error

## 설계 근거
1. **Harmony 패치 회피**: GameplayUIManager.Awake 패치는 Inspector serialized field 의존이라 prefab 변경 시 깨짐. 런타임 FindObjectOfType + Instantiate 가 더 robust.
2. **Clone vs build-from-scratch**: 게임 UI 스타일 자동 매치 (폰트/색/패딩/punch 효과 등). prefab 분석 부담 없음.
3. **viewTypeName 추적 단절**: 원본 entry 컴포넌트 destroy 로 게임의 onOpen/onClose 이벤트 추적과 분리. 인디케이터는 미동작이지만 click 만 살림.

## 미구현 (Out of Scope, 후속)
- **인디케이터 동기화**: panel 이 ManagedUIElement 아니라 자동 X. fake View publish 로 sync 가능 (별도 PR).
- **다른 View 활성 시 panel 자동 close**: ActiveView 변경 구독 필요.

## 인게임 검증 항목
- [ ] 첫 인벤토리 (I 키) 진입 시 "Char" 탭 등장
- [ ] 탭 클릭 → CharacterPanel 토글
- [ ] 기존 탭들 (Inventory/Crafting/Quests) 정상 동작 (회귀 없음)
- [ ] 인젝트 실패 시 게임 정상 진행 (try-catch sentinel)

## Test plan
- [x] dotnet build clean
- [x] ManagedUIElement (Duckov.UI) / ViewTabs (global) namespace 정확
- [x] CharacterPanel.Instance 노출
- [ ] (사용자) 인게임 인벤토리 → 탭 출현 + 클릭 동작

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)