### PR TITLE
chore(#35): remove DamageActionPatch diag log

### DIFF
--- a/src/QuackForge.Progression/Patches/DamageActionPatch.cs
+++ b/src/QuackForge.Progression/Patches/DamageActionPatch.cs
@@ -11,7 +11,7 @@ namespace QuackForge.Progression.Patches
     // 해결: DamageAction 실행 스코프 동안 thread-static 플래그를 켜고, 그 동안엔
     // Health.MaxHealth getter 가 우리 보너스를 빼서 반환 (HealthMaxHealthDamageScopePatch).
     // Prefix 에서 set, Finalizer 에서 clear (예외 시에도 안전).
-    [HarmonyPatch("Duckov.Effects.DamageAction", "OnTriggeredPositive")]
+    [HarmonyPatch(typeof(Duckov.Effects.DamageAction), "OnTriggeredPositive")]
     public static class DamageActionPatch
     {
         [System.ThreadStatic]


### PR DESCRIPTION
IT5 round 에서 D 패치 호출 + VitBonus 정확 출력 검증 완료. 진단 로그 제거.

- IT5 결과: Prefix #1~#3+ 호출, VitBonus 0→10 점진 증가 확인
- HP 깎임은 game 자체 percent damage debuff 메커니즘 (raid 시간 진행 시 발생)
- 우리 D 패치는 game 데미지 그대로 적용 (보너스 분만 빼서 부작용 방지)

Refs #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)